### PR TITLE
[feat(tools)] add multi-site downloader progress and site browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@shikijs/transformers": "^3.23.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/lodash.kebabcase": "^4.1.9",
-    "@typescript-eslint/parser": "^8.57.1",
+    "@typescript-eslint/parser": "^8.57.2",
     "eslint": "^9.39.4",
     "eslint-plugin-astro": "^1.6.0",
     "globals": "^16.5.0",
@@ -47,8 +47,8 @@
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.57.1",
-    "wrangler": "^4.75.0"
+    "typescript-eslint": "^8.57.2",
+    "wrangler": "^4.77.0"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Nuus Portfolio",
   "type": "module",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "packageManager": "pnpm@10.29.3",
   "scripts": {
     "dev": "astro dev --host",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^12.6.13
-        version: 12.6.13(@types/node@24.12.0)(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 12.6.13(@types/node@24.12.0)(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
       '@astrojs/rss':
         specifier: ^4.0.17
         version: 4.0.17
@@ -26,10 +26,10 @@ importers:
         version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+        version: 4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@5.9.3)(yaml@2.8.3)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -77,8 +77,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9
       '@typescript-eslint/parser':
-        specifier: ^8.57.1
-        version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: ^8.57.2
+        version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -104,11 +104,11 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.57.1
-        version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: ^8.57.2
+        version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       wrangler:
-        specifier: ^4.75.0
-        version: 4.75.0(@cloudflare/workers-types@4.20260317.1)
+        specifier: ^4.77.0
+        version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
 
 packages:
 
@@ -125,6 +125,9 @@ packages:
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
+
+  '@astrojs/compiler@3.0.1':
+    resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
 
   '@astrojs/internal-helpers@0.7.6':
     resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
@@ -198,8 +201,8 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/unenv-preset@2.15.0':
-    resolution: {integrity: sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==}
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
@@ -1298,141 +1301,141 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+  '@rollup/rollup-darwin-x64@4.60.0':
+    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
@@ -1610,63 +1613,63 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.57.1':
-    resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
+  '@typescript-eslint/eslint-plugin@8.57.2':
+    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.57.1
+      '@typescript-eslint/parser': ^8.57.2
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.57.1':
-    resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.57.1':
-    resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.57.1':
-    resolution: {integrity: sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.57.1':
-    resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.57.1':
-    resolution: {integrity: sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==}
+  '@typescript-eslint/parser@8.57.2':
+    resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.57.1':
-    resolution: {integrity: sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.57.1':
-    resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
+  '@typescript-eslint/project-service@8.57.2':
+    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.57.1':
-    resolution: {integrity: sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==}
+  '@typescript-eslint/scope-manager@8.57.2':
+    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.2':
+    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.57.2':
+    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.57.1':
-    resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
+  '@typescript-eslint/types@8.57.2':
+    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.57.2':
+    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.57.2':
+    resolution: {integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.57.2':
+    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -1758,8 +1761,8 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
-  astro-eslint-parser@1.3.0:
-    resolution: {integrity: sha512-aOLc/aDR7lTWAHlytEefwn4Y6qs6uMr69DZvUx2A1AOAZsWhGB/paiRWPtVchh9wzMvLeqr+DkbENhVreVr9AQ==}
+  astro-eslint-parser@1.4.0:
+    resolution: {integrity: sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   astro@5.18.1:
@@ -1807,8 +1810,8 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1992,8 +1995,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@8.0.3:
-    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dlv@1.1.3:
@@ -2039,6 +2042,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   error-stack-parser-es@1.0.5:
@@ -2171,8 +2178,8 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.5.7:
-    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
+  fast-xml-parser@5.5.9:
+    resolution: {integrity: sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==}
     hasBin: true
 
   fastq@1.20.1:
@@ -2255,8 +2262,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  h3@1.15.9:
-    resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
+  h3@1.15.10:
+    resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2659,8 +2666,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  miniflare@4.20260317.0:
-    resolution: {integrity: sha512-xuwk5Kjv+shi5iUBAdCrRl9IaWSGnTU8WuTQzsUS2GlSDIMCJuu8DiF/d9ExjMXYiQG5ml+k9SVKnMj8cRkq0w==}
+  miniflare@4.20260317.2:
+    resolution: {integrity: sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2795,12 +2802,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   postcss-selector-parser@6.0.10:
@@ -2992,8 +2999,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+  rollup@4.60.0:
+    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3053,8 +3060,8 @@ packages:
     resolution: {integrity: sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==}
     engines: {node: '>=8.0.0'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -3093,8 +3100,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.1:
-    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
+  strnum@2.2.2:
+    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
 
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
@@ -3123,8 +3130,8 @@ packages:
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
   tiny-inflate@1.0.3:
@@ -3185,8 +3192,8 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript-eslint@8.57.1:
-    resolution: {integrity: sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==}
+  typescript-eslint@8.57.2:
+    resolution: {integrity: sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3209,8 +3216,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3509,9 +3516,9 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
-  wrangler@4.75.0:
-    resolution: {integrity: sha512-Efk1tcnm4eduBYpH1sSjMYydXMnIFPns/qABI3+fsbDrUk5GksNYX8nYGVP4sFygvGPO7kJc36YJKB5ooA7JAg==}
-    engines: {node: '>=20.0.0'}
+  wrangler@4.77.0:
+    resolution: {integrity: sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==}
+    engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260317.1
@@ -3555,8 +3562,8 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3626,14 +3633,14 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@12.6.13(@types/node@24.12.0)(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)':
+  '@astrojs/cloudflare@12.6.13(@types/node@24.12.0)(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.6
       '@astrojs/underscore-redirects': 1.0.0
       '@cloudflare/workers-types': 4.20260317.1
-      astro: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@5.9.3)(yaml@2.8.3)
       tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
       wrangler: 4.59.2(@cloudflare/workers-types@4.20260317.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -3651,6 +3658,8 @@ snapshots:
       - yaml
 
   '@astrojs/compiler@2.13.1': {}
+
+  '@astrojs/compiler@3.0.1': {}
 
   '@astrojs/internal-helpers@0.7.6': {}
 
@@ -3697,7 +3706,7 @@ snapshots:
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       shiki: 3.23.0
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -3712,7 +3721,7 @@ snapshots:
 
   '@astrojs/rss@4.0.17':
     dependencies:
-      fast-xml-parser: 5.5.7
+      fast-xml-parser: 5.5.9
       piccolore: 0.1.3
       zod: 4.3.6
 
@@ -3738,7 +3747,7 @@ snapshots:
 
   '@astrojs/yaml2ts@0.2.3':
     dependencies:
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -3765,7 +3774,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260114.0
 
-  '@cloudflare/unenv-preset@2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)':
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
@@ -4423,87 +4432,87 @@ snapshots:
       '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
-  '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
+  '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.59.0
+      rollup: 4.60.0
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
+  '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.59.0':
+  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
+  '@rollup/rollup-darwin-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.59.0':
+  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
+  '@rollup/rollup-freebsd-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
+  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
+  '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
+  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
+  '@rollup/rollup-openharmony-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
   '@shikijs/core@3.23.0':
@@ -4619,12 +4628,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   '@types/debug@4.1.13':
     dependencies:
@@ -4666,14 +4675,14 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/type-utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/type-utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.2
       eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -4682,41 +4691,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.57.1':
+  '@typescript-eslint/scope-manager@8.57.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
 
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4724,14 +4733,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.57.1': {}
+  '@typescript-eslint/types@8.57.2': {}
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
@@ -4741,20 +4750,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.57.1':
+  '@typescript-eslint/visitor-keys@8.57.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -4850,7 +4859,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@5.0.2: {}
 
@@ -4860,14 +4869,14 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  astro-eslint-parser@1.3.0:
+  astro-eslint-parser@1.4.0:
     dependencies:
-      '@astrojs/compiler': 2.13.1
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@2.13.1)
+      '@astrojs/compiler': 3.0.1
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      astrojs-compiler-sync: 1.1.1(@astrojs/compiler@3.0.1)
       debug: 4.4.3
-      entities: 6.0.1
+      entities: 7.0.1
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -4877,7 +4886,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -4885,7 +4894,7 @@ snapshots:
       '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 4.0.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.0)
       acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -4898,7 +4907,7 @@ snapshots:
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
       devalue: 5.6.4
-      diff: 8.0.3
+      diff: 8.0.4
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 1.7.0
@@ -4919,12 +4928,12 @@ snapshots:
       p-queue: 8.1.1
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.4
       shiki: 3.23.0
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       svgo: 4.0.1
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -4934,8 +4943,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -4979,9 +4988,9 @@ snapshots:
       - uploadthing
       - yaml
 
-  astrojs-compiler-sync@1.1.1(@astrojs/compiler@2.13.1):
+  astrojs-compiler-sync@1.1.1(@astrojs/compiler@3.0.1):
     dependencies:
-      '@astrojs/compiler': 2.13.1
+      '@astrojs/compiler': 3.0.1
       synckit: 0.11.12
 
   axobject-query@4.1.0: {}
@@ -5016,7 +5025,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5172,7 +5181,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@8.0.3: {}
+  diff@8.0.4: {}
 
   dlv@1.1.3: {}
 
@@ -5210,11 +5219,13 @@ snapshots:
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.2
 
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -5353,8 +5364,8 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@typescript-eslint/types': 8.57.1
-      astro-eslint-parser: 1.3.0
+      '@typescript-eslint/types': 8.57.2
+      astro-eslint-parser: 1.4.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-compat-utils: 0.6.5(eslint@9.39.4(jiti@2.6.1))
       globals: 16.5.0
@@ -5463,19 +5474,19 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.5.7:
+  fast-xml-parser@5.5.9:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
-      strnum: 2.2.1
+      strnum: 2.2.2
 
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fflate@0.7.4: {}
 
@@ -5532,7 +5543,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h3@1.15.9:
+  h3@1.15.10:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
@@ -6125,13 +6136,13 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   miniflare@4.20260114.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.5
+      undici: 7.24.6
       workerd: 1.20260114.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -6140,11 +6151,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260317.0:
+  miniflare@4.20260317.2:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.5
+      undici: 7.24.6
       workerd: 1.20260317.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -6154,7 +6165,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
@@ -6281,9 +6292,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -6461,35 +6472,35 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.59.0:
+  rollup@4.60.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
+      '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
+      '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
+      '@rollup/rollup-win32-x64-gnu': 4.60.0
+      '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -6585,7 +6596,7 @@ snapshots:
 
   slugify@1.6.8: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -6622,7 +6633,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.1: {}
+  strnum@2.2.2: {}
 
   suf-log@2.5.3:
     dependencies:
@@ -6654,7 +6665,7 @@ snapshots:
 
   tailwindcss@4.2.2: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.2: {}
 
   tiny-inflate@1.0.3: {}
 
@@ -6662,8 +6673,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6697,12 +6708,12 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  typescript-eslint@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6718,7 +6729,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.24.5: {}
+  undici@7.24.6: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -6792,7 +6803,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.9
+      h3: 1.15.10
       lru-cache: 11.2.7
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
@@ -6819,24 +6830,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
-      rollup: 4.59.0
+      rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -6982,13 +6993,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.75.0(@cloudflare/workers-types@4.20260317.1):
+  wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260317.0
+      miniflare: 4.20260317.2
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260317.1
@@ -7033,7 +7044,7 @@ snapshots:
 
   yaml@2.7.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/components/BackButton.astro
+++ b/src/components/BackButton.astro
@@ -20,7 +20,7 @@ import { SITE } from "@/config";
 }
 
 <script>
-  /* Update Search Praam */
+  /* Update Search Param */
   function updateGoBackUrl() {
     const backButton: HTMLAnchorElement | null =
       document.querySelector("#back-button");

--- a/src/components/BackToTopButton.astro
+++ b/src/components/BackToTopButton.astro
@@ -6,7 +6,7 @@ import IconArrowNarrowUp from "@/assets/icons/IconArrowNarrowUp.svg";
 <div
   id="btt-btn-container"
   class:list={[
-    "fixed end-4 bottom-8 z-50",
+    "fixed inset-e-4 bottom-8 z-50",
     "md:sticky md:end-auto md:float-end md:me-1",
     "translate-y-14 opacity-0 transition duration-500",
   ]}

--- a/src/components/tools/RecaptchaConfig.astro
+++ b/src/components/tools/RecaptchaConfig.astro
@@ -16,14 +16,3 @@ const toolsBackendUrl = (PUBLIC_TOOLS_BACKEND_URL ?? "").trim();
   data-ytdlp-backend-url={toolsBackendUrl}
 >
 </div>
-
-{
-  recaptchaSiteKey && (
-    <script
-      src="https://www.google.com/recaptcha/api.js?render=explicit"
-      is:inline
-      async
-      defer
-    />
-  )
-}

--- a/src/data/blog/portfolio-changelog-2026.md
+++ b/src/data/blog/portfolio-changelog-2026.md
@@ -18,7 +18,7 @@ description: A comprehensive nadzu.me Portfolio Changelog documenting updates fo
 - _Resolve issues with the Manual Deployment Pipeline, as it is currently non-functional._
 - _Add GTAG Functionality_
 
-## v2.3.5 - 2026-03-27
+## v2.4.0 - 2026-03-27
 
 - <a href="https://github.com/nxdun/Portfolio/pull/24" target="_blank"><code>#24</code></a> [feat(tools)] Improve downloader experience and expand supported platforms
   - Upgraded the downloader from YouTube-only to a broader AIO downloader experience with support for many platforms.

--- a/src/data/blog/portfolio-changelog-2026.md
+++ b/src/data/blog/portfolio-changelog-2026.md
@@ -18,6 +18,15 @@ description: A comprehensive nadzu.me Portfolio Changelog documenting updates fo
 - _Resolve issues with the Manual Deployment Pipeline, as it is currently non-functional._
 - _Add GTAG Functionality_
 
+## v2.3.5 - 2026-03-27
+
+- <a href="https://github.com/nxdun/Portfolio/pull/24" target="_blank"><code>#24</code></a> [feat(tools)] Improve downloader experience and expand supported platforms
+  - Upgraded the downloader from YouTube-only to a broader AIO downloader experience with support for many platforms.
+  - Added live download progress updates for clearer feedback while files are being prepared.
+  - Added a supported sites browser so users can quickly check which platforms are available.
+  - Updated downloader messaging and interface for a smoother, more user-friendly flow.
+  - Refined related UI details and refreshed project dependencies.
+
 <a name="v2.3.4"></a>
 
 ## v2.3.4 - 2026-03-20

--- a/src/data/blog/rust-backend-changelog-2026.md
+++ b/src/data/blog/rust-backend-changelog-2026.md
@@ -16,6 +16,13 @@ description: A comprehensive nadzu.me Rust Backend Changelog documenting updates
 
 - _Separate CAPTCHA Verification endpoint_
 
+## v0.1.3 - 2026-03-22
+
+- <a href="https://github.com/nxdun/rust-codebase/pull/7" target="_blank"><code>#7</code></a>[feat(infra)] Add dev environment and refactor yt-dlp selector
+  - Added local Docker Compose stack (`Dockerfile.dev`, `Caddy`, `cargo-watch`).
+  - [#6](https://github.com/nxdun/rust-codebase/issues/6). Fixed `yt-dlp` format and sort flag logic for better media extraction.
+  - Streamlined Makefile targets and secured `.dockerignore`.
+
 ## v0.1.2 - 2024-03-17
 
 - <a href="https://github.com/nxdun/rust-codebase/pull/5" target="_blank"><code>#5</code></a>[infra] Add Cloudflare DNS integration and wildcard CORS

--- a/src/data/blog/rust-backend-changelog-2026.md
+++ b/src/data/blog/rust-backend-changelog-2026.md
@@ -16,6 +16,15 @@ description: A comprehensive nadzu.me Rust Backend Changelog documenting updates
 
 - _Separate CAPTCHA Verification endpoint_
 
+## v0.2.0 - 2026-03-27
+
+- <a href="https://github.com/nxdun/rust-codebase/pull/8" target="_blank"><code>#8</code></a>[feat(ytdlp)] Add streaming progress and supported sites API
+  - SSE endpoint for live yt-dlp job download progress updates.
+  - Added supported sites endpoint listing all available download platforms.
+  - Replaced bgutil/POT provider with `aria2c` for faster multi-connection downloading.
+  - Introduced `MASTER_API_KEY` auth middleware; replaces dev bypass header.
+  - **Breaking:** `YTDLP_COOKIES_FILE`, `YTDLP_POT_PROVIDER_URL`, and `YTDLP_PRESIGNED_URL` env vars removed. YouTube Shorts URL normalization removed.
+
 ## v0.1.3 - 2026-03-22
 
 - <a href="https://github.com/nxdun/rust-codebase/pull/7" target="_blank"><code>#7</code></a>[feat(infra)] Add dev environment and refactor yt-dlp selector

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -349,6 +349,11 @@ const defaultTool = TOOL_CATALOG.find(
     box-shadow: 0 0 0 1px color-mix(in oklab, #f59e0b 32%, transparent);
   }
 
+  #tool-view-panel[data-response-state="downloading"] {
+    border-color: color-mix(in oklab, #f59e0b 70%, var(--border));
+    box-shadow: 0 0 0 1px color-mix(in oklab, #f59e0b 38%, transparent);
+  }
+
   #tool-view-panel[data-response-state="success"] {
     border-color: color-mix(in oklab, #10b981 58%, var(--border));
     box-shadow: 0 0 0 1px color-mix(in oklab, #10b981 30%, transparent);

--- a/src/scripts/tools/catalog.ts
+++ b/src/scripts/tools/catalog.ts
@@ -7,9 +7,9 @@ export const TOOL_CATALOG = [
   },
   {
     key: "ytdlp",
-    title: "YouTube Downloader",
-    description: "Queue video download",
-    subtitle: "Submit a YouTube video URL after reCAPTCHA verification.",
+    title: "AIO Downloader",
+    description: "Multi-site video downloader",
+    subtitle: "Submit a video URL from one of 2000+ supported sites.",
   },
 ] as const;
 

--- a/src/scripts/tools/ui/progressBar.ts
+++ b/src/scripts/tools/ui/progressBar.ts
@@ -1,0 +1,87 @@
+export type ToolProgressBarRefs = {
+  wrapEl: HTMLElement;
+  barEl: HTMLElement;
+  metaEl: HTMLElement;
+};
+
+export type ToolProgressBarUpdate = {
+  percent: number | null;
+  meta: string;
+};
+
+export type ToolProgressBar = {
+  hide: () => void;
+  reset: () => void;
+  update: (next: ToolProgressBarUpdate) => void;
+  getPercent: () => number | null;
+};
+
+const DEFAULT_META = "Waiting for progress...";
+
+export function createToolProgressBar(
+  refs: ToolProgressBarRefs
+): ToolProgressBar {
+  let lastMeta = "";
+  let lastPercent: number | null = null;
+  let peakPercent = 0;
+
+  const applyMeta = (meta: string): void => {
+    if (meta === lastMeta) {
+      return;
+    }
+
+    refs.metaEl.textContent = meta;
+    lastMeta = meta;
+  };
+
+  const applyPercent = (percent: number | null): void => {
+    if (percent === null) {
+      if (lastPercent === null) {
+        return;
+      }
+
+      refs.barEl.style.width = "0%";
+      refs.barEl.setAttribute("aria-valuenow", "0");
+      lastPercent = null;
+      peakPercent = 0;
+      return;
+    }
+
+    const clamped = Math.max(0, Math.min(100, percent));
+    const monotonic = Math.max(clamped, peakPercent);
+    const rounded = Math.round(monotonic);
+
+    if (lastPercent !== null && rounded === Math.round(lastPercent)) {
+      peakPercent = monotonic;
+      return;
+    }
+
+    refs.barEl.style.width = `${rounded}%`;
+    refs.barEl.setAttribute("aria-valuenow", rounded.toString());
+    lastPercent = monotonic;
+    peakPercent = monotonic;
+  };
+
+  const reset = (): void => {
+    refs.wrapEl.classList.add("hidden");
+    refs.barEl.style.width = "0%";
+    refs.barEl.setAttribute("aria-valuenow", "0");
+    refs.metaEl.textContent = DEFAULT_META;
+    lastMeta = "";
+    lastPercent = null;
+    peakPercent = 0;
+  };
+
+  return {
+    hide: () => {
+      refs.wrapEl.classList.add("hidden");
+    },
+    reset,
+    update: next => {
+      refs.wrapEl.classList.remove("hidden");
+      applyPercent(next.percent);
+      applyMeta(next.meta || DEFAULT_META);
+    },
+    getPercent: () => lastPercent,
+  };
+}

--- a/src/scripts/tools/ui/responseDock.ts
+++ b/src/scripts/tools/ui/responseDock.ts
@@ -1,6 +1,9 @@
+import { createToolProgressBar } from "./progressBar";
+
 export type ToolResponseState =
   | "idle"
   | "pending"
+  | "downloading"
   | "success"
   | "fail"
   | "disabled";
@@ -15,6 +18,7 @@ type ToolResponseDockOptions = {
 const TOOL_RESPONSE_STATE_STYLE: Record<ToolResponseState, string> = {
   idle: "border-border/70 bg-muted/20 text-foreground/85",
   pending: "border-amber-500/60 bg-amber-500/10 text-amber-300",
+  downloading: "border-amber-500/70 bg-amber-500/14 text-amber-300",
   success: "border-emerald-500/60 bg-emerald-500/10 text-emerald-300",
   fail: "border-rose-500/60 bg-rose-500/10 text-rose-300",
   disabled: "border-slate-500/60 bg-slate-500/10 text-slate-300",
@@ -23,9 +27,19 @@ const TOOL_RESPONSE_STATE_STYLE: Record<ToolResponseState, string> = {
 const TOOL_RESPONSE_STATE_LABEL: Record<ToolResponseState, string> = {
   idle: "Ready",
   pending: "Pending",
+  downloading: "Downloading",
   success: "Success",
   fail: "Failed",
   disabled: "Disabled",
+};
+
+const TOOL_PROGRESS_BAR_STYLE: Record<ToolResponseState, string> = {
+  idle: "bg-foreground/35",
+  pending: "bg-amber-400",
+  downloading: "bg-amber-400",
+  success: "bg-emerald-400",
+  fail: "bg-rose-400",
+  disabled: "bg-slate-400",
 };
 
 export type ToolResponseDock = {
@@ -34,6 +48,8 @@ export type ToolResponseDock = {
     message: string,
     options?: { showWhenIdle?: boolean }
   ) => void;
+  setProgress: (percent: number | null, meta: string) => void;
+  clearProgress: () => void;
   getState: () => ToolResponseState;
   hide: () => void;
   clear: () => void;
@@ -68,6 +84,23 @@ export function createToolResponseDock(
         <span class="text-[11px] opacity-70">Tool Status</span>
       </div>
       <p id="tool-response-message" class="mt-1 text-xs opacity-90">Awaiting action.</p>
+
+      <div id="tool-response-progress-wrap" class="mt-2 hidden" aria-live="polite" aria-atomic="true">
+        <div class="mb-1 text-[11px] opacity-80">
+          <span id="tool-response-progress-meta" class="block truncate">Waiting for progress...</span>
+        </div>
+        <div class="h-2 w-full overflow-hidden rounded-full bg-current/15">
+          <div
+            id="tool-response-progress-bar"
+            class="h-full w-0 rounded-full ${TOOL_PROGRESS_BAR_STYLE.idle} transition-[width] duration-200 ease-linear"
+            role="progressbar"
+            aria-label="Task progress"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="0"
+          ></div>
+        </div>
+      </div>
     </section>
   `;
 
@@ -83,10 +116,29 @@ export function createToolResponseDock(
   const dismissBtn = host.querySelector(
     "#tool-response-dismiss"
   ) as HTMLButtonElement | null;
+  const progressWrapEl = host.querySelector(
+    "#tool-response-progress-wrap"
+  ) as HTMLElement | null;
+  const progressBarEl = host.querySelector(
+    "#tool-response-progress-bar"
+  ) as HTMLElement | null;
+  const progressMetaEl = host.querySelector(
+    "#tool-response-progress-meta"
+  ) as HTMLElement | null;
 
-  if (!statusEl || !labelEl || !messageEl || !dismissBtn) {
+  if (
+    !statusEl ||
+    !labelEl ||
+    !messageEl ||
+    !dismissBtn ||
+    !progressWrapEl ||
+    !progressBarEl ||
+    !progressMetaEl
+  ) {
     return {
       setState: () => {},
+      setProgress: () => {},
+      clearProgress: () => {},
       getState: () => "idle",
       hide: () => host.classList.add("hidden"),
       clear: () => {
@@ -105,6 +157,24 @@ export function createToolResponseDock(
     showWhenIdle: boolean;
   } | null = null;
 
+  const progressBar = createToolProgressBar({
+    wrapEl: progressWrapEl,
+    barEl: progressBarEl,
+    metaEl: progressMetaEl,
+  });
+
+  const applyProgressTone = (state: ToolResponseState): void => {
+    progressBarEl.classList.remove(
+      TOOL_PROGRESS_BAR_STYLE.idle,
+      TOOL_PROGRESS_BAR_STYLE.pending,
+      TOOL_PROGRESS_BAR_STYLE.downloading,
+      TOOL_PROGRESS_BAR_STYLE.success,
+      TOOL_PROGRESS_BAR_STYLE.fail,
+      TOOL_PROGRESS_BAR_STYLE.disabled
+    );
+    progressBarEl.classList.add(TOOL_PROGRESS_BAR_STYLE[state]);
+  };
+
   const setVisible = (visible: boolean) => {
     host.classList.toggle("hidden", !visible);
   };
@@ -119,6 +189,11 @@ export function createToolResponseDock(
     statusEl.className = `rounded-2xl border px-3 py-2 text-sm transition-colors ${TOOL_RESPONSE_STATE_STYLE[state]}`;
     labelEl.textContent = TOOL_RESPONSE_STATE_LABEL[state];
     messageEl.textContent = message;
+    applyProgressTone(state);
+
+    if (state !== "pending" && state !== "downloading") {
+      progressBar.reset();
+    }
 
     const persist = state === "disabled";
     dismissBtn.disabled = persist;
@@ -128,6 +203,14 @@ export function createToolResponseDock(
     const shouldShow = !hiddenOnIdle || state !== "idle" || showWhenIdle;
     setVisible(shouldShow);
     options?.onStateChange?.(state);
+  };
+
+  const setProgress: ToolResponseDock["setProgress"] = (percent, meta) => {
+    progressBar.update({ percent, meta });
+  };
+
+  const clearProgress: ToolResponseDock["clearProgress"] = () => {
+    progressBar.reset();
   };
 
   const setState: ToolResponseDock["setState"] = (
@@ -141,6 +224,11 @@ export function createToolResponseDock(
       window.clearTimeout(pendingStateTimer);
       pendingStateTimer = null;
       pendingPayload = null;
+    }
+
+    if (state === currentState) {
+      applyState(state, message, showWhenIdle);
+      return;
     }
 
     const now = Date.now();
@@ -176,12 +264,15 @@ export function createToolResponseDock(
 
   return {
     setState,
+    setProgress,
+    clearProgress,
     getState: () => currentState,
     hide: () => setVisible(false),
     clear: () => {
       if (pendingStateTimer !== null) {
         window.clearTimeout(pendingStateTimer);
       }
+      progressBar.reset();
       host.innerHTML = "";
       host.classList.add("hidden");
       options?.onStateChange?.("idle");

--- a/src/scripts/tools/ytdlp/apiClient.ts
+++ b/src/scripts/tools/ytdlp/apiClient.ts
@@ -1,15 +1,49 @@
 import { sanitizeText } from "../validation";
 import { CoreApiClient, type ApiResult } from "../../../utils/CoreApiClient";
+import {
+  toYtdlpTerminalState,
+  normalizeYtdlpJobStatus,
+} from "../../../utils/ytdlpStatus";
 
 const YTDLP_ENQUEUE_PATH = "/api/v1/ytdlp";
 const YTDLP_JOB_PATH = "/api/v1/ytdlp/jobs";
+const YTDLP_STREAM_SUFFIX = "/stream";
 const YTDLP_DOWNLOAD_PATH = "/api/v1/ytdlp/download";
+const YTDLP_SITES_PATH = "/api/v1/ytdlp/sites";
 
 export type YtdlpJobState = "pending" | "success" | "fail" | "unknown";
 
 export type YtdlpDownloadFile = {
   blob: Blob;
   fileName: string;
+};
+
+export type YtdlpJobSnapshot = {
+  status: string;
+  progressPercent: number | null;
+  progressTotal: string | null;
+  progressSpeed: string | null;
+  progressEta: string | null;
+  progressMessage: string | null;
+  updatedAtUnix: number | null;
+};
+
+export type YtdlpStreamProgress = YtdlpJobSnapshot;
+
+export type YtdlpStreamError = {
+  errorType: "NETWORK_DOWN" | "BAD_REQUEST" | "UNKNOWN";
+  message: string;
+  shouldFallbackToPolling: boolean;
+};
+
+export type YtdlpStreamSubscription = {
+  close: () => void;
+};
+
+type YtdlpStreamCallbacks = {
+  onProgress: (progress: YtdlpStreamProgress) => void;
+  onDone: () => void;
+  onError: (error: YtdlpStreamError) => void;
 };
 
 function readStatus(job: Record<string, unknown>): string {
@@ -21,7 +55,210 @@ function readStatus(job: Record<string, unknown>): string {
   ).toLowerCase();
 }
 
+function readOptionalText(value: unknown, maxLength = 256): string | null {
+  return (
+    sanitizeText(typeof value === "string" ? value : null, {
+      maxLength,
+      preserveWhitespace: false,
+    }) ?? null
+  );
+}
+
+function readOptionalPercent(value: unknown): number | null {
+  const numberValue = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isFinite(numberValue)) {
+    return null;
+  }
+
+  const clamped = Math.max(0, Math.min(100, numberValue));
+  return Math.round(clamped * 10) / 10;
+}
+
+function readOptionalUnix(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.trunc(value);
+}
+
+function toSnapshot(job: Record<string, unknown>): YtdlpJobSnapshot {
+  return {
+    status: normalizeYtdlpJobStatus(readStatus(job)),
+    progressPercent: readOptionalPercent(job.progress_percent),
+    progressTotal: readOptionalText(job.progress_total, 64),
+    progressSpeed: readOptionalText(job.progress_speed, 64),
+    progressEta: readOptionalText(job.progress_eta, 64),
+    progressMessage: readOptionalText(job.progress_message, 512),
+    updatedAtUnix: readOptionalUnix(job.updated_at_unix),
+  };
+}
+
+function readJobId(job: Record<string, unknown>): string | null {
+  return (
+    sanitizeText(typeof job.id === "string" ? job.id : null, {
+      maxLength: 128,
+      preserveWhitespace: false,
+    }) ?? null
+  );
+}
+
+function resolveJobPayload(
+  payload: Record<string, unknown> | null | undefined
+): Record<string, unknown> | null {
+  if (!payload) {
+    return null;
+  }
+
+  // Support both SSE/API shapes: { job: {...} } and flat { status, progress_* }.
+  const wrapped =
+    payload && typeof payload === "object" ? (payload.job as unknown) : null;
+  if (wrapped && typeof wrapped === "object") {
+    return wrapped as Record<string, unknown>;
+  }
+
+  if (typeof payload.status === "string") {
+    return payload;
+  }
+
+  return null;
+}
+
 export class YtdlpApiClient extends CoreApiClient {
+  private async fetchJob(
+    jobId: string,
+    signal?: AbortSignal
+  ): Promise<ApiResult<Record<string, unknown>>> {
+    const response = await this.getJson(
+      `${YTDLP_JOB_PATH}/${encodeURIComponent(jobId)}`,
+      signal
+    );
+
+    if (!response.ok) {
+      return response;
+    }
+
+    const payload = this.asObject(response.data);
+    const job = resolveJobPayload(payload);
+
+    if (!job) {
+      return {
+        ok: false,
+        errorType: "UNKNOWN",
+        message: "Unexpected status response.",
+      };
+    }
+
+    return {
+      ok: true,
+      data: job,
+    };
+  }
+
+  openJobStream(
+    jobId: string,
+    callbacks: YtdlpStreamCallbacks
+  ): ApiResult<YtdlpStreamSubscription> {
+    const target = `${YTDLP_JOB_PATH}/${encodeURIComponent(jobId)}${YTDLP_STREAM_SUFFIX}`;
+
+    let eventSource: EventSource;
+
+    try {
+      eventSource = new EventSource(this.resolveUrl(target));
+    } catch {
+      return {
+        ok: false,
+        errorType: "UNKNOWN",
+        message: "Could not start progress stream.",
+      };
+    }
+
+    const close = (): void => {
+      eventSource.close();
+    };
+
+    let handledCustomError = false;
+
+    const onProgress = (event: MessageEvent): void => {
+      try {
+        const payload = this.asObject(JSON.parse(event.data));
+        const job = resolveJobPayload(payload);
+        if (!job) {
+          return;
+        }
+
+        callbacks.onProgress(toSnapshot(job));
+      } catch {
+        callbacks.onError({
+          errorType: "UNKNOWN",
+          message: "Progress update was malformed.",
+          shouldFallbackToPolling: true,
+        });
+      }
+    };
+
+    const onDone = (): void => {
+      callbacks.onDone();
+    };
+
+    const onCustomError = (event: Event): void => {
+      if (!(event instanceof MessageEvent)) {
+        return;
+      }
+
+      handledCustomError = true;
+
+      try {
+        const payload = this.asObject(JSON.parse(event.data));
+        const status =
+          typeof payload?.status === "number" ? payload.status : undefined;
+        const message =
+          readOptionalText(payload?.message, 160) ??
+          "Progress stream failed for this job.";
+
+        callbacks.onError({
+          errorType: status === 404 ? "BAD_REQUEST" : "UNKNOWN",
+          message,
+          shouldFallbackToPolling: false,
+        });
+      } catch {
+        callbacks.onError({
+          errorType: "UNKNOWN",
+          message: "Progress stream failed for this job.",
+          shouldFallbackToPolling: false,
+        });
+      }
+    };
+
+    const onTransportError = (): void => {
+      if (handledCustomError) {
+        return;
+      }
+
+      if (eventSource.readyState === EventSource.CONNECTING) {
+        return;
+      }
+
+      callbacks.onError({
+        errorType: "NETWORK_DOWN",
+        message: "Live progress interrupted. Switching to backup checks.",
+        shouldFallbackToPolling: true,
+      });
+    };
+
+    eventSource.addEventListener("progress", onProgress as EventListener);
+    eventSource.addEventListener("done", onDone as EventListener);
+    eventSource.addEventListener("error", onCustomError as EventListener);
+    eventSource.onerror = onTransportError;
+
+    return {
+      ok: true,
+      data: {
+        close,
+      },
+    };
+  }
+
   async enqueue(
     url: string,
     captchaToken: string,
@@ -44,10 +281,7 @@ export class YtdlpApiClient extends CoreApiClient {
 
     const payload = this.asObject(response.data);
     const job = this.asObject(payload?.job);
-    const jobId = sanitizeText(typeof job?.id === "string" ? job.id : null, {
-      maxLength: 128,
-      preserveWhitespace: false,
-    });
+    const jobId = job ? readJobId(job) : null;
 
     if (!jobId) {
       return {
@@ -63,43 +297,57 @@ export class YtdlpApiClient extends CoreApiClient {
     };
   }
 
-  async checkJobStatus(
-    jobId: string,
-    signal?: AbortSignal
-  ): Promise<ApiResult<YtdlpJobState>> {
-    const response = await this.getJson(
-      `${YTDLP_JOB_PATH}/${encodeURIComponent(jobId)}`,
-      signal
-    );
+  async getSites(signal?: AbortSignal): Promise<ApiResult<string[]>> {
+    const response = await this.getJson(YTDLP_SITES_PATH, signal);
 
     if (!response.ok) {
       return response;
     }
 
     const payload = this.asObject(response.data);
-    const job = this.asObject(payload?.job);
+    const sites = Array.isArray(payload?.sites) ? payload.sites : [];
 
-    if (!job) {
-      return {
-        ok: false,
-        errorType: "UNKNOWN",
-        message: "Unexpected status response.",
-      };
+    return {
+      ok: true,
+      data: sites.map(site => String(site)),
+    };
+  }
+
+  async checkJobStatus(
+    jobId: string,
+    signal?: AbortSignal
+  ): Promise<ApiResult<YtdlpJobState>> {
+    const jobResult = await this.fetchJob(jobId, signal);
+    if (!jobResult.ok) {
+      return jobResult;
     }
 
-    const status = readStatus(job);
-
-    if (["failed", "error", "cancelled", "canceled"].includes(status)) {
+    const status = normalizeYtdlpJobStatus(readStatus(jobResult.data));
+    const terminal = toYtdlpTerminalState(status);
+    if (terminal === "fail") {
       return { ok: true, data: "fail" };
     }
 
-    if (
-      ["completed", "complete", "done", "finished", "success"].includes(status)
-    ) {
+    if (terminal === "success") {
       return { ok: true, data: "success" };
     }
 
     return { ok: true, data: "pending" };
+  }
+
+  async getJobSnapshot(
+    jobId: string,
+    signal?: AbortSignal
+  ): Promise<ApiResult<YtdlpJobSnapshot>> {
+    const jobResult = await this.fetchJob(jobId, signal);
+    if (!jobResult.ok) {
+      return jobResult;
+    }
+
+    return {
+      ok: true,
+      data: toSnapshot(jobResult.data),
+    };
   }
 
   async downloadFile(

--- a/src/scripts/tools/ytdlp/controller.ts
+++ b/src/scripts/tools/ytdlp/controller.ts
@@ -2,16 +2,15 @@ import { createToolResponseDock } from "../ui/responseDock";
 import { readClipboardText } from "../clipboard";
 import type { ToolTeardown, YtdlpToolOptions } from "../types";
 import { validateYtdlpActionInput } from "./validation";
-import { asyncPoll } from "../../../utils/asyncPoll";
-import { YtdlpApiClient } from "./apiClient";
+import type { YtdlpApiClient } from "./apiClient";
 import { CaptchaManager } from "../../../utils/captchaManager";
 import type { ApiErrorType, ApiResult } from "../../../utils/CoreApiClient";
 import type { YtdlpDomRefs } from "./dom";
 import { YtdlpUiController } from "./uiController";
 import type { CaptchaDialogController } from "../ui/captchaDialog";
+import { YtdlpSitesController } from "./sitesController";
+import { YtdlpJobMonitor, type StreamMonitorResult } from "./jobMonitor";
 
-const POLL_INTERVAL_MS = 5000;
-const MAX_POLL_ATTEMPTS = 60;
 const SERVICE_UNAVAILABLE_MESSAGE =
   "Download service is currently unavailable due to maintenance. Please try again later.";
 const SERVICE_UNREACHABLE_MESSAGE =
@@ -37,6 +36,8 @@ export type YtdlpControllerConfig = {
 export class YtdlpToolController {
   private readonly responseDock: ReturnType<typeof createToolResponseDock>;
   private readonly ui: YtdlpUiController;
+  private readonly sitesController: YtdlpSitesController;
+  private readonly jobMonitor: YtdlpJobMonitor;
 
   private readonly cleanupCallbacks: Array<() => void> = [];
   private activeAbortController: AbortController | null = null;
@@ -70,7 +71,7 @@ export class YtdlpToolController {
     this.captchaDialog = config.captchaDialog;
 
     this.responseDock = createToolResponseDock(this.responseHost, {
-      title: "YouTube Downloader Response",
+      title: "AIO Downloader Response",
       hiddenOnIdle: true,
       minStateDurationMs: 220,
       onStateChange: state => {
@@ -87,14 +88,29 @@ export class YtdlpToolController {
         setDockState: (state, message, options) => {
           this.responseDock.setState(state, message, options);
         },
+        setDockProgress: (percent, meta) => {
+          this.responseDock.setProgress(percent, meta);
+        },
+        clearDockProgress: () => {
+          this.responseDock.clearProgress();
+        },
       },
       this.isCaptchaFeatureEnabled,
       () => (this.captchaManager?.getToken().trim().length ?? 0) > 0
+    );
+
+    this.sitesController = new YtdlpSitesController(this.refs, this.apiClient);
+
+    this.jobMonitor = new YtdlpJobMonitor(
+      this.apiClient,
+      this.ui,
+      this.handleApiFailure.bind(this)
     );
   }
 
   init(): ToolTeardown {
     this.bindEvents();
+    this.sitesController.init();
 
     if (typeof this.options?.url === "string") {
       this.refs.inputEl.value = this.options.url;
@@ -107,13 +123,9 @@ export class YtdlpToolController {
       return () => this.destroy();
     }
 
-    this.ui.transition(
-      "IDLE",
-      "Paste a YouTube URL and click Submit Download.",
-      {
-        showWhenIdle: true,
-      }
-    );
+    this.ui.transition("IDLE", "Paste a video URL and click Submit Download.", {
+      showWhenIdle: true,
+    });
 
     void this.ensureServiceHealth();
 
@@ -362,71 +374,52 @@ export class YtdlpToolController {
       this.captchaDialog.close();
 
       this.readyJobId = null;
+      this.jobMonitor.resetProgressKey();
       this.ui.setPrimaryStage("pending");
-      this.ui.transition("POLLING", "Downloading... Please wait.");
-
-      const result = await asyncPoll<"success" | "fail" | "handled-error">({
-        intervalMs: POLL_INTERVAL_MS,
-        maxAttempts: MAX_POLL_ATTEMPTS,
-        signal,
-        step: async () => {
-          const statusResult = await apiClient.checkJobStatus(jobId, signal);
-
-          if (!statusResult.ok) {
-            if (
-              this.handleApiFailure(statusResult, {
-                shouldResetCaptcha: true,
-              }) === "silent"
-            ) {
-              return { done: true, value: "handled-error" };
-            }
-
-            return { done: true, value: "handled-error" };
-          }
-
-          if (statusResult.data === "fail") {
-            return { done: true, value: "fail" };
-          }
-
-          if (statusResult.data === "success") {
-            return { done: true, value: "success" };
-          }
-
-          return { done: false };
-        },
-      });
-
-      if (result === "success") {
-        this.readyJobId = jobId;
-        this.ui.setPrimaryStage("download");
-        this.ui.transition("READY", "Download is ready.");
-        return;
-      }
-
-      if (result === "fail") {
-        this.readyJobId = null;
-        this.ui.setPrimaryStage("submit");
-        this.ui.transition("ERROR", "Download failed. Try another URL.");
-        return;
-      }
-
-      if (result === "handled-error") {
-        this.readyJobId = null;
-        return;
-      }
-
-      this.readyJobId = null;
-      this.ui.setPrimaryStage("submit");
+      this.ui.setPendingProgress("Queued", null);
       this.ui.transition(
-        "ERROR",
-        "Download is taking longer than expected. Please try again."
+        "POLLING",
+        "Download started. Waiting for progress..."
       );
+
+      const result = await this.jobMonitor.monitorJob(jobId, signal);
+      this.applyMonitorResult(result, jobId);
     } catch (error) {
       if (!isAbortError(error)) {
         this.readyJobId = null;
         this.disableService("NETWORK_DOWN");
       }
     }
+  }
+
+  private applyMonitorResult(result: StreamMonitorResult, jobId: string): void {
+    this.jobMonitor.resetProgressKey();
+
+    if (result === "success") {
+      this.readyJobId = jobId;
+      this.ui.setPrimaryStage("download");
+      this.ui.transition("READY", "Download is ready.");
+      return;
+    }
+
+    if (result === "fail") {
+      this.readyJobId = null;
+      this.ui.setPrimaryStage("submit");
+      this.ui.transition("ERROR", "Download failed. Try another URL.");
+      return;
+    }
+
+    if (result === "handled-error") {
+      this.readyJobId = null;
+      return;
+    }
+
+    this.readyJobId = null;
+    this.ui.setPrimaryStage("submit");
+    this.ui.transition(
+      "ERROR",
+      "Download is taking longer than expected. Please try again."
+    );
   }
 
   private async handleDownloadClick(): Promise<void> {
@@ -531,6 +524,7 @@ export class YtdlpToolController {
     this.refs.inputEl.value = "";
     this.pendingUrl = "";
     this.readyJobId = null;
+    this.jobMonitor.resetProgressKey();
     this.ui.setPrimaryStage("submit");
     this.captchaDialog.close();
     this.captchaManager?.reset();
@@ -563,6 +557,8 @@ export class YtdlpToolController {
   }
 
   private disableService(errorType?: ApiErrorType): void {
+    this.abortActiveOperation();
+
     this.serviceDisabledMessage =
       errorType === "NETWORK_DOWN"
         ? SERVICE_UNREACHABLE_MESSAGE
@@ -585,6 +581,8 @@ export class YtdlpToolController {
       this.activeAbortController.abort();
       this.activeAbortController = null;
     }
+
+    this.jobMonitor.closeActiveStream();
   }
 
   private addEventListener(
@@ -611,6 +609,7 @@ export class YtdlpToolController {
     this.captchaDialog.close();
     this.captchaDialog.destroy();
     this.responseDock.clear();
+    this.sitesController.destroy();
 
     if (this.toolViewPanel) {
       this.toolViewPanel.dataset.responseState = "idle";

--- a/src/scripts/tools/ytdlp/dom.ts
+++ b/src/scripts/tools/ytdlp/dom.ts
@@ -3,6 +3,12 @@ export type YtdlpDomRefs = {
   pasteBtn: HTMLButtonElement;
   clearBtn: HTMLButtonElement;
   submitBtn: HTMLButtonElement;
+  viewSitesBtn: HTMLButtonElement;
+  sitesDialog: HTMLDialogElement;
+  sitesCloseBtn: HTMLButtonElement;
+  sitesSearchInput: HTMLInputElement;
+  sitesList: HTMLElement;
+  sitesCount: HTMLElement;
 };
 
 export function resolveYtdlpDomRefs(
@@ -20,8 +26,37 @@ export function resolveYtdlpDomRefs(
   const submitBtn = container.querySelector(
     "#ytdlp-submit"
   ) as HTMLButtonElement | null;
+  const viewSitesBtn = container.querySelector(
+    "#ytdlp-view-sites"
+  ) as HTMLButtonElement | null;
+  const sitesDialog = container.querySelector(
+    "#ytdlp-sites-dialog"
+  ) as HTMLDialogElement | null;
+  const sitesCloseBtn = container.querySelector(
+    "#ytdlp-sites-close"
+  ) as HTMLButtonElement | null;
+  const sitesSearchInput = container.querySelector(
+    "#ytdlp-sites-search"
+  ) as HTMLInputElement | null;
+  const sitesList = container.querySelector(
+    "#ytdlp-sites-list"
+  ) as HTMLElement | null;
+  const sitesCount = container.querySelector(
+    "#ytdlp-sites-count"
+  ) as HTMLElement | null;
 
-  if (!inputEl || !pasteBtn || !clearBtn || !submitBtn) {
+  if (
+    !inputEl ||
+    !pasteBtn ||
+    !clearBtn ||
+    !submitBtn ||
+    !viewSitesBtn ||
+    !sitesDialog ||
+    !sitesCloseBtn ||
+    !sitesSearchInput ||
+    !sitesList ||
+    !sitesCount
+  ) {
     return null;
   }
 
@@ -30,5 +65,11 @@ export function resolveYtdlpDomRefs(
     pasteBtn,
     clearBtn,
     submitBtn,
+    viewSitesBtn,
+    sitesDialog,
+    sitesCloseBtn,
+    sitesSearchInput,
+    sitesList,
+    sitesCount,
   };
 }

--- a/src/scripts/tools/ytdlp/jobMonitor.ts
+++ b/src/scripts/tools/ytdlp/jobMonitor.ts
@@ -1,0 +1,218 @@
+import { asyncPoll } from "../../../utils/asyncPoll";
+import type {
+  YtdlpApiClient,
+  YtdlpJobSnapshot,
+  YtdlpStreamSubscription,
+} from "./apiClient";
+import type { ApiResult } from "../../../utils/CoreApiClient";
+import { YtdlpUiController } from "./uiController";
+import { toYtdlpTerminalState } from "../../../utils/ytdlpStatus";
+import {
+  createYtdlpProgressKey,
+  buildYtdlpProgressMessage,
+  buildYtdlpProgressMeta,
+} from "../../../utils/ytdlpProgress";
+import { getYtdlpProgressLabel } from "../../../utils/ytdlpStatus";
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_ATTEMPTS = 60;
+
+export type StreamMonitorResult =
+  | "success"
+  | "fail"
+  | "fallback"
+  | "handled-error"
+  | "timeout";
+
+export class YtdlpJobMonitor {
+  private activeStream: YtdlpStreamSubscription | null = null;
+  private lastProgressKey = "";
+
+  constructor(
+    private readonly apiClient: YtdlpApiClient | undefined,
+    private readonly ui: YtdlpUiController,
+    private readonly onApiFailure: (
+      result: Extract<ApiResult<unknown>, { ok: false }>,
+      options?: { shouldResetCaptcha?: boolean }
+    ) => "silent" | "handled"
+  ) {}
+
+  public async monitorJob(
+    jobId: string,
+    signal: AbortSignal
+  ): Promise<StreamMonitorResult> {
+    let result = await this.monitorJobWithStream(jobId, signal);
+    if (result === "fallback") {
+      result = await this.monitorJobWithPolling(jobId, signal);
+    }
+    return result;
+  }
+
+  public closeActiveStream(): void {
+    if (!this.activeStream) return;
+    this.activeStream.close();
+    this.activeStream = null;
+  }
+
+  public resetProgressKey(): void {
+    this.lastProgressKey = "";
+  }
+
+  private applyProgressUpdate(snapshot: YtdlpJobSnapshot): void {
+    const nextKey = createYtdlpProgressKey(snapshot);
+
+    if (nextKey === this.lastProgressKey) {
+      return;
+    }
+
+    this.lastProgressKey = nextKey;
+
+    const label = getYtdlpProgressLabel(snapshot.status);
+    const message = buildYtdlpProgressMessage(snapshot);
+
+    this.ui.setPendingProgress(label, snapshot.progressPercent);
+    this.ui.setPendingDetails(buildYtdlpProgressMeta(snapshot));
+    this.ui.transition("POLLING", message);
+  }
+
+  private async monitorJobWithStream(
+    jobId: string,
+    signal: AbortSignal
+  ): Promise<StreamMonitorResult> {
+    if (!this.apiClient) return "handled-error";
+
+    const apiClient = this.apiClient;
+
+    return await new Promise<StreamMonitorResult>(resolve => {
+      let lastSnapshot: YtdlpJobSnapshot | null = null;
+      let settled = false;
+
+      const settle = (value: StreamMonitorResult): void => {
+        if (settled) return;
+        settled = true;
+        this.closeActiveStream();
+        resolve(value);
+      };
+
+      const streamResult = apiClient.openJobStream(jobId, {
+        onProgress: snapshot => {
+          if (settled || signal.aborted) return;
+          lastSnapshot = snapshot;
+          this.applyProgressUpdate(snapshot);
+        },
+        onDone: () => {
+          if (settled || signal.aborted) return;
+          void this.resolveFinalStatus(jobId, lastSnapshot, signal).then(
+            settle,
+            () => settle("handled-error")
+          );
+        },
+        onError: error => {
+          if (settled || signal.aborted) return;
+          if (error.shouldFallbackToPolling) {
+            this.ui.transition("POLLING", error.message);
+            settle("fallback");
+            return;
+          }
+          this.ui.setPrimaryStage("submit");
+          this.ui.transition("ERROR", error.message);
+          settle("handled-error");
+        },
+      });
+
+      if (!streamResult.ok) {
+        if (
+          this.onApiFailure(streamResult, {
+            shouldResetCaptcha: true,
+          }) === "silent"
+        ) {
+          settle("handled-error");
+          return;
+        }
+        settle("handled-error");
+        return;
+      }
+
+      this.activeStream = streamResult.data;
+
+      signal.addEventListener(
+        "abort",
+        () => {
+          settle("handled-error");
+        },
+        { once: true }
+      );
+    });
+  }
+
+  private async monitorJobWithPolling(
+    jobId: string,
+    signal: AbortSignal
+  ): Promise<StreamMonitorResult> {
+    if (!this.apiClient) return "handled-error";
+
+    const apiClient = this.apiClient;
+    this.ui.setPendingProgress("Checking", null);
+    this.ui.setPendingDetails(
+      "Progress stream is unavailable. Falling back to polling."
+    );
+    this.ui.transition("POLLING", "Checking download status...");
+
+    const result = await asyncPoll<"success" | "fail" | "handled-error">({
+      intervalMs: POLL_INTERVAL_MS,
+      maxAttempts: MAX_POLL_ATTEMPTS,
+      signal,
+      step: async () => {
+        const statusResult = await apiClient.checkJobStatus(jobId, signal);
+
+        if (!statusResult.ok) {
+          if (
+            this.onApiFailure(statusResult, {
+              shouldResetCaptcha: true,
+            }) === "silent"
+          ) {
+            return { done: true, value: "handled-error" };
+          }
+          return { done: true, value: "handled-error" };
+        }
+
+        if (statusResult.data === "fail") return { done: true, value: "fail" };
+        if (statusResult.data === "success")
+          return { done: true, value: "success" };
+
+        return { done: false };
+      },
+    });
+
+    if (!result) return "timeout";
+    return result;
+  }
+
+  private async resolveFinalStatus(
+    jobId: string,
+    lastSnapshot: YtdlpJobSnapshot | null,
+    signal: AbortSignal
+  ): Promise<StreamMonitorResult> {
+    if (!this.apiClient) return "handled-error";
+
+    const snapshotResult = await this.apiClient.getJobSnapshot(jobId, signal);
+    if (!snapshotResult.ok) {
+      if (
+        this.onApiFailure(snapshotResult, {
+          shouldResetCaptcha: true,
+        }) === "silent"
+      ) {
+        return "handled-error";
+      }
+      return "handled-error";
+    }
+
+    const terminal = toYtdlpTerminalState(snapshotResult.data.status);
+    if (terminal) return terminal;
+
+    const fallbackTerminal = toYtdlpTerminalState(lastSnapshot?.status ?? "");
+    if (fallbackTerminal) return fallbackTerminal;
+
+    return "timeout";
+  }
+}

--- a/src/scripts/tools/ytdlp/sitesController.ts
+++ b/src/scripts/tools/ytdlp/sitesController.ts
@@ -1,0 +1,145 @@
+import type { YtdlpDomRefs } from "./dom";
+import type { YtdlpApiClient } from "./apiClient";
+
+const RANDOM_SITES_PREVIEW_COUNT = 60;
+const SITES_RENDER_LIMIT = 500;
+
+export class YtdlpSitesController {
+  private supportedSites: string[] = [];
+  private sitesLoaded = false;
+  private readonly cleanupCallbacks: Array<() => void> = [];
+
+  constructor(
+    private readonly refs: YtdlpDomRefs,
+    private readonly apiClient: YtdlpApiClient | undefined
+  ) {}
+
+  public init(): void {
+    this.addEventListener(this.refs.viewSitesBtn, "click", () => {
+      void this.handleViewSitesClick();
+    });
+
+    this.addEventListener(this.refs.sitesCloseBtn, "click", () => {
+      this.refs.sitesDialog.close();
+    });
+
+    this.addEventListener(this.refs.sitesSearchInput, "input", () => {
+      this.handleSitesSearch();
+    });
+  }
+
+  public destroy(): void {
+    this.cleanupCallbacks.forEach(cleanup => cleanup());
+    this.cleanupCallbacks.length = 0;
+  }
+
+  private addEventListener(
+    target: EventTarget,
+    type: string,
+    listener: EventListenerOrEventListenerObject
+  ): void {
+    target.addEventListener(type, listener);
+    this.cleanupCallbacks.push(() => {
+      target.removeEventListener(type, listener);
+    });
+  }
+
+  private async handleViewSitesClick(): Promise<void> {
+    this.refs.sitesDialog.showModal();
+    this.refs.sitesSearchInput.value = "";
+
+    if (this.sitesLoaded) {
+      this.renderRandomSitesPreview();
+      return;
+    }
+
+    if (!this.apiClient) return;
+
+    this.refs.sitesList.innerHTML =
+      '<div class="col-span-full py-6 text-center text-muted-foreground">Loading...</div>';
+
+    try {
+      const result = await this.apiClient.getSites();
+      if (result.ok) {
+        this.supportedSites = result.data;
+        this.sitesLoaded = true;
+        this.refs.sitesCount.textContent =
+          this.supportedSites.length.toString();
+        this.renderRandomSitesPreview();
+      } else {
+        this.refs.sitesList.innerHTML =
+          '<div class="col-span-full py-6 text-center text-red-500">Failed to load sites.</div>';
+      }
+    } catch {
+      this.refs.sitesList.innerHTML =
+        '<div class="col-span-full py-6 text-center text-red-500">Failed to load sites.</div>';
+    }
+  }
+
+  private handleSitesSearch(): void {
+    const query = this.refs.sitesSearchInput.value.toLowerCase().trim();
+    if (!query) {
+      this.renderRandomSitesPreview();
+      return;
+    }
+
+    if (query.includes("youtube") || query.includes("youtu.be")) {
+      this.refs.sitesList.innerHTML =
+        '<div class="col-span-full py-6 text-center"><p class="mb-1 text-sm font-semibold text-red-500">Removed YouTube Download</p><p class="text-xs text-muted-foreground">This feature is disabled due to legal constraints.</p></div>';
+      return;
+    }
+
+    const filtered = this.supportedSites.filter(s =>
+      s.toLowerCase().includes(query)
+    );
+    this.renderSites(filtered);
+  }
+
+  private renderRandomSitesPreview(): void {
+    if (this.supportedSites.length <= RANDOM_SITES_PREVIEW_COUNT) {
+      this.renderSites(this.supportedSites);
+      return;
+    }
+
+    const randomIndexes = new Set<number>();
+    while (randomIndexes.size < RANDOM_SITES_PREVIEW_COUNT) {
+      randomIndexes.add(Math.floor(Math.random() * this.supportedSites.length));
+    }
+
+    const randomSites = Array.from(
+      randomIndexes,
+      index => this.supportedSites[index]
+    );
+
+    this.renderSites(randomSites);
+  }
+
+  private renderSites(sites: string[]): void {
+    if (sites.length === 0) {
+      this.refs.sitesList.innerHTML =
+        '<div class="col-span-full py-6 text-center"><p class="mb-1 text-muted-foreground">No matching sites found.</p><p class="text-xs text-muted-foreground opacity-75">Notice: YouTube downloading has been removed due to legal issues.</p></div>';
+      return;
+    }
+
+    const toRender = sites.slice(0, SITES_RENDER_LIMIT);
+    this.refs.sitesList.innerHTML = toRender
+      .map(site => {
+        const safeSite = this.escapeHtml(site);
+        return `<article class="min-w-0 rounded-lg border border-border/40 bg-background/70 px-3 py-2.5"><p class="truncate text-sm font-medium leading-tight" title="${safeSite}">${safeSite}</p></article>`;
+      })
+      .join("");
+
+    if (sites.length > SITES_RENDER_LIMIT) {
+      this.refs.sitesList.innerHTML += `<div class="col-span-full px-2 py-3 text-center text-xs text-muted-foreground">Showing first ${SITES_RENDER_LIMIT.toLocaleString()} results. Refine search to narrow matches.</div>`;
+    }
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+  }
+}

--- a/src/scripts/tools/ytdlp/template.ts
+++ b/src/scripts/tools/ytdlp/template.ts
@@ -3,7 +3,7 @@ export const YTDLP_TOOL_TEMPLATE = `
     <div class="grid gap-2 relative group/input">
       <div class="flex items-center justify-between">
         <label class="text-sm font-semibold flex items-center gap-2" for="ytdlp-url-input">
-          YouTube URL
+          Video URL
         </label>
         <div class="flex items-center gap-2 flex-wrap">
           <button
@@ -30,11 +30,13 @@ export const YTDLP_TOOL_TEMPLATE = `
         id="ytdlp-url-input"
         type="url"
         class="h-11 rounded-xl border border-border/60 bg-muted/5 px-4 text-sm focus:border-accent focus:ring-1 focus:ring-accent outline-none transition-all"
-        placeholder="https://www.youtube.com/watch?v=..."
+        placeholder="https://example.com/video"
         autocomplete="off"
         inputmode="url"
       />
-      <p class="text-xs opacity-75">Only single YouTube videos are allowed. Playlists are blocked.</p>
+      <div class="flex items-center justify-between">
+        <p class="text-xs opacity-75">Paste a video URL from one of <button type="button" id="ytdlp-view-sites" class="font-bold text-accent hover:underline outline-none">2000+ supported sites</button>.</p>
+      </div>
     </div>
 
     <div class="flex gap-3">
@@ -46,5 +48,33 @@ export const YTDLP_TOOL_TEMPLATE = `
         Submit Download
       </button>
     </div>
+
+    <dialog id="ytdlp-sites-dialog" class="m-auto h-[min(82vh,760px)] w-[94vw] max-w-5xl overflow-hidden rounded-2xl border border-border/60 bg-background/95 p-0 text-foreground shadow-2xl backdrop:bg-background/80 backdrop:backdrop-blur-sm">
+      <div class="flex h-full flex-col">
+        <header class="border-b border-border/50 px-5 py-4 sm:px-6">
+          <div class="flex items-start justify-between gap-4">
+            <div class="grid gap-1">
+              <h3 class="text-lg font-bold leading-none">Supported Sites (<span id="ytdlp-sites-count">0</span>+)</h3>
+              <p class="text-xs text-muted-foreground">Search across providers and verify your URL host quickly.</p>
+            </div>
+            <button id="ytdlp-sites-close" type="button" class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" aria-label="Close supported sites dialog">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12z"/></svg>
+            </button>
+          </div>
+        </header>
+
+        <div class="border-b border-border/50 px-5 py-3 sm:px-6 sm:py-4">
+          <div class="relative">
+            <input type="text" id="ytdlp-sites-search" placeholder="Search by domain or platform name..." class="h-11 w-full rounded-xl border border-border/60 bg-muted/5 px-4 text-sm outline-none transition-all focus:border-accent focus:ring-1 focus:ring-accent" />
+          </div>
+        </div>
+
+        <div class="min-h-0 flex-1 px-5 py-4 sm:px-6">
+          <div id="ytdlp-sites-list" class="grid h-full min-h-56 grid-cols-1 content-start gap-2 overflow-y-auto rounded-xl border border-border/50 bg-muted/10 p-2 text-sm sm:p-3 md:grid-cols-2">
+            <div class="col-span-full py-6 text-center text-muted-foreground">Loading...</div>
+          </div>
+        </div>
+      </div>
+    </dialog>
   </section>
 `;

--- a/src/scripts/tools/ytdlp/uiController.ts
+++ b/src/scripts/tools/ytdlp/uiController.ts
@@ -19,11 +19,38 @@ type ResponseBridge = {
     message: string,
     options?: { showWhenIdle?: boolean }
   ) => void;
+  setDockProgress: (percent: number | null, meta: string) => void;
+  clearDockProgress: () => void;
 };
 
 export class YtdlpUiController {
   private state: YtdlpUiState = "IDLE";
   private primaryStage: PrimaryStage = "submit";
+  private pendingPercent: number | null = null;
+
+  private readonly responseToneClasses = [
+    "border-accent",
+    "bg-accent/5",
+    "text-accent",
+    "hover:bg-accent",
+    "hover:text-white",
+    "border-amber-500",
+    "bg-amber-500/10",
+    "text-amber-300",
+    "hover:bg-amber-500",
+    "border-green-600",
+    "bg-green-600",
+    "text-white",
+    "hover:bg-green-700",
+    "border-rose-500",
+    "bg-rose-500/10",
+    "text-rose-300",
+    "hover:bg-rose-500",
+    "border-slate-500",
+    "bg-slate-500/10",
+    "text-slate-300",
+    "hover:bg-slate-500",
+  ] as const;
 
   constructor(
     private readonly refs: YtdlpDomRefs,
@@ -33,12 +60,102 @@ export class YtdlpUiController {
     private readonly hasCaptchaToken: () => boolean
   ) {}
 
+  private hideProgress(): void {
+    this.pendingPercent = null;
+    this.responseState.clearDockProgress();
+  }
+
+  private renderProgressBar(percent: number | null, meta: string): void {
+    this.pendingPercent = percent;
+    this.responseState.setDockProgress(percent, meta);
+  }
+
+  private applySubmitButtonTone(state: ToolResponseState): void {
+    const submitBtn = this.refs.submitBtn;
+    submitBtn.classList.remove(...this.responseToneClasses);
+
+    if (state === "idle") {
+      submitBtn.classList.add(
+        "border-accent",
+        "bg-accent/5",
+        "text-accent",
+        "hover:bg-accent",
+        "hover:text-white"
+      );
+      return;
+    }
+
+    if (state === "pending" || state === "downloading") {
+      submitBtn.classList.add(
+        "border-amber-500",
+        "bg-amber-500/10",
+        "text-amber-300",
+        "hover:bg-amber-500",
+        "hover:text-white"
+      );
+      return;
+    }
+
+    if (state === "success") {
+      submitBtn.classList.add(
+        "border-green-600",
+        "bg-green-600",
+        "text-white",
+        "hover:bg-green-700"
+      );
+      return;
+    }
+
+    if (state === "fail") {
+      submitBtn.classList.add(
+        "border-rose-500",
+        "bg-rose-500/10",
+        "text-rose-300",
+        "hover:bg-rose-500",
+        "hover:text-white"
+      );
+      return;
+    }
+
+    submitBtn.classList.add(
+      "border-slate-500",
+      "bg-slate-500/10",
+      "text-slate-300",
+      "hover:bg-slate-500",
+      "hover:text-white"
+    );
+  }
+
+  setPendingProgress(label: string, percent: number | null): void {
+    if (this.primaryStage !== "pending") {
+      return;
+    }
+
+    const cleanedLabel = label.trim() || "Downloading";
+    const percentText =
+      typeof percent === "number" && Number.isFinite(percent)
+        ? ` ${Math.round(percent)}%`
+        : "";
+
+    this.refs.submitBtn.textContent = "Please wait";
+    this.renderProgressBar(percent, `${cleanedLabel}${percentText}`);
+  }
+
+  setPendingDetails(details: string): void {
+    if (this.primaryStage !== "pending") {
+      return;
+    }
+
+    this.renderProgressBar(this.pendingPercent, details);
+  }
+
   setPrimaryStage(stage: PrimaryStage): void {
     this.primaryStage = stage;
 
     const { submitBtn } = this.refs;
 
     if (stage === "submit") {
+      this.hideProgress();
       submitBtn.textContent = "Submit Download";
       submitBtn.classList.remove(
         "bg-green-600",
@@ -57,37 +174,13 @@ export class YtdlpUiController {
     }
 
     if (stage === "pending") {
-      submitBtn.textContent = "Downloading... Please wait";
-      submitBtn.classList.remove(
-        "bg-green-600",
-        "border-green-600",
-        "text-white",
-        "hover:bg-green-700"
-      );
-      submitBtn.classList.add(
-        "border-accent",
-        "bg-accent/5",
-        "text-accent",
-        "hover:bg-accent",
-        "hover:text-white"
-      );
+      submitBtn.textContent = "Please wait";
+      this.renderProgressBar(null, "Waiting for progress...");
       return;
     }
 
     submitBtn.textContent = "Save File";
-    submitBtn.classList.remove(
-      "border-accent",
-      "bg-accent/5",
-      "text-accent",
-      "hover:bg-accent",
-      "hover:text-white"
-    );
-    submitBtn.classList.add(
-      "bg-green-600",
-      "border-green-600",
-      "text-white",
-      "hover:bg-green-700"
-    );
+    this.hideProgress();
   }
 
   getPrimaryStage(): PrimaryStage {
@@ -102,12 +195,10 @@ export class YtdlpUiController {
     this.state = nextState;
 
     let dockState: ToolResponseState = "idle";
-    if (
-      nextState === "LOADING_CAPTCHA" ||
-      nextState === "SUBMITTING" ||
-      nextState === "POLLING"
-    ) {
+    if (nextState === "LOADING_CAPTCHA" || nextState === "SUBMITTING") {
       dockState = "pending";
+    } else if (nextState === "POLLING") {
+      dockState = "downloading";
     } else if (nextState === "READY") {
       dockState = "success";
     } else if (nextState === "ERROR") {
@@ -117,6 +208,7 @@ export class YtdlpUiController {
     }
 
     this.responseState.setDockState(dockState, message, options);
+    this.applySubmitButtonTone(dockState);
     this.syncInteractiveState();
   }
 

--- a/src/scripts/tools/ytdlp/validation.ts
+++ b/src/scripts/tools/ytdlp/validation.ts
@@ -10,14 +10,6 @@ export const YTDLP_BACKEND_URL_MAX_LENGTH = 512;
 export const YTDLP_RECAPTCHA_SITE_KEY_MAX_LENGTH = 256;
 export const YTDLP_CAPTCHA_TOKEN_MAX_LENGTH = 4096;
 
-const YOUTUBE_HOSTS = new Set([
-  "youtube.com",
-  "www.youtube.com",
-  "m.youtube.com",
-  "music.youtube.com",
-  "youtu.be",
-]);
-
 export type YtdlpActionInput = {
   url?: string;
   backendUrl?: string;
@@ -75,7 +67,7 @@ function validateHttpUrl(value: string, label: string): ToolValidationResult {
   }
 }
 
-function normalizeYouTubeUrl(url: string): YtdlpActionValidationResult {
+function normalizeVideoUrl(url: string): YtdlpActionValidationResult {
   const textValidation = validateToolTextInput(url, {
     label: "URL",
     required: true,
@@ -104,67 +96,10 @@ function normalizeYouTubeUrl(url: string): YtdlpActionValidationResult {
     };
   }
 
-  const hostname = parsed.hostname.toLowerCase();
-  if (!YOUTUBE_HOSTS.has(hostname)) {
-    return {
-      isValid: false,
-      message: "Only YouTube video URLs are allowed.",
-    };
-  }
-
-  if (parsed.searchParams.has("list") || parsed.pathname === "/playlist") {
-    return {
-      isValid: false,
-      message: "Playlists are not allowed.",
-    };
-  }
-
-  if (hostname === "youtu.be") {
-    const videoId = parsed.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
-    if (!videoId) {
-      return {
-        isValid: false,
-        message: "Please provide a valid YouTube video URL.",
-      };
-    }
-
-    return {
-      isValid: true,
-      normalized: {
-        url: `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`,
-      },
-    };
-  }
-
-  if (parsed.pathname.startsWith("/shorts/")) {
-    const shortId = parsed.pathname.replace("/shorts/", "").split("/")[0] ?? "";
-    if (!shortId) {
-      return {
-        isValid: false,
-        message: "Please provide a valid YouTube Shorts URL.",
-      };
-    }
-
-    return {
-      isValid: true,
-      normalized: {
-        url: `https://www.youtube.com/watch?v=${encodeURIComponent(shortId)}`,
-      },
-    };
-  }
-
-  const videoId = parsed.searchParams.get("v")?.trim() ?? "";
-  if (!videoId) {
-    return {
-      isValid: false,
-      message: "Please provide a valid YouTube watch URL.",
-    };
-  }
-
   return {
     isValid: true,
     normalized: {
-      url: `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`,
+      url: parsed.href,
     },
   };
 }
@@ -224,7 +159,7 @@ export function validateYtdlpActionInput(
       preserveWhitespace: false,
     });
 
-    const urlValidation = normalizeYouTubeUrl(url ?? "");
+    const urlValidation = normalizeVideoUrl(url ?? "");
     if (!urlValidation.isValid) {
       return urlValidation;
     }

--- a/src/utils/captchaManager.ts
+++ b/src/utils/captchaManager.ts
@@ -82,6 +82,8 @@ export class CaptchaManager {
       return true;
     }
 
+    this.injectScriptIfNeeded();
+
     const startedAt = Date.now();
     while (Date.now() - startedAt <= this.timeoutMs) {
       if (signal?.aborted || this.disposed) {
@@ -156,6 +158,20 @@ export class CaptchaManager {
       window.clearTimeout(timeoutId);
     });
     this.pendingTimeouts.clear();
+  }
+
+  private injectScriptIfNeeded(): void {
+    const SCRIPT_URL =
+      "https://www.google.com/recaptcha/api.js?render=explicit";
+    if (document.querySelector(`script[src="${SCRIPT_URL}"]`)) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = SCRIPT_URL;
+    script.async = true;
+    script.defer = true;
+    document.head.appendChild(script);
   }
 
   private sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/utils/ytdlpProgress.ts
+++ b/src/utils/ytdlpProgress.ts
@@ -1,0 +1,51 @@
+import type { YtdlpJobSnapshot } from "@/scripts/tools/ytdlp/apiClient";
+import { getYtdlpProgressLabel } from "./ytdlpStatus";
+
+export function createYtdlpProgressKey(snapshot: YtdlpJobSnapshot): string {
+  return [
+    snapshot.status,
+    snapshot.progressPercent,
+    snapshot.progressSpeed,
+    snapshot.progressEta,
+    snapshot.progressTotal,
+    snapshot.updatedAtUnix,
+  ].join("|");
+}
+
+export function buildYtdlpProgressMessage(snapshot: YtdlpJobSnapshot): string {
+  if (snapshot.progressMessage) {
+    return snapshot.progressMessage;
+  }
+
+  const label = getYtdlpProgressLabel(snapshot.status);
+  const percentText =
+    typeof snapshot.progressPercent === "number"
+      ? ` ${Math.round(snapshot.progressPercent)}%`
+      : "";
+  const speedText = snapshot.progressSpeed ? ` ${snapshot.progressSpeed}` : "";
+  const etaText = snapshot.progressEta ? ` ETA ${snapshot.progressEta}` : "";
+
+  return `${label}...${percentText}${speedText}${etaText}`.trim();
+}
+
+export function buildYtdlpProgressMeta(snapshot: YtdlpJobSnapshot): string {
+  const parts: string[] = [];
+
+  if (typeof snapshot.progressPercent === "number") {
+    parts.push(`${Math.round(snapshot.progressPercent)}%`);
+  }
+
+  if (snapshot.progressSpeed) {
+    parts.push(snapshot.progressSpeed);
+  }
+
+  if (snapshot.progressTotal) {
+    parts.push(snapshot.progressTotal);
+  }
+
+  if (snapshot.progressEta) {
+    parts.push(`ETA ${snapshot.progressEta}`);
+  }
+
+  return parts.join(" • ") || "Waiting for progress...";
+}

--- a/src/utils/ytdlpStatus.ts
+++ b/src/utils/ytdlpStatus.ts
@@ -1,0 +1,67 @@
+const STATUS_MAX_LENGTH = 80;
+
+export type YtdlpTerminalState = "success" | "fail";
+
+export function normalizeYtdlpJobStatus(status: string): string {
+  return status.trim().toLowerCase().slice(0, STATUS_MAX_LENGTH);
+}
+
+export function isYtdlpSuccessStatus(status: string): boolean {
+  const normalized = normalizeYtdlpJobStatus(status);
+  return ["completed", "complete", "done", "finished", "success"].includes(
+    normalized
+  );
+}
+
+export function isYtdlpFailureStatus(status: string): boolean {
+  const normalized = normalizeYtdlpJobStatus(status);
+  return ["failed", "error", "cancelled", "canceled"].includes(normalized);
+}
+
+export function toYtdlpTerminalState(
+  status: string
+): YtdlpTerminalState | null {
+  if (isYtdlpSuccessStatus(status)) {
+    return "success";
+  }
+
+  if (isYtdlpFailureStatus(status)) {
+    return "fail";
+  }
+
+  return null;
+}
+
+export function getYtdlpProgressLabel(status: string): string {
+  const normalized = normalizeYtdlpJobStatus(status);
+
+  if (["queued", "pending", "waiting"].includes(normalized)) {
+    return "Queued";
+  }
+
+  if (["running", "downloading", "processing"].includes(normalized)) {
+    return "Downloading";
+  }
+
+  if (
+    ["extracting", "preparing", "analyzing", "metadata"].includes(normalized)
+  ) {
+    return "Preparing";
+  }
+
+  if (
+    ["merging", "muxing", "finalizing", "postprocessing"].includes(normalized)
+  ) {
+    return "Finalizing";
+  }
+
+  if (isYtdlpSuccessStatus(normalized)) {
+    return "Finishing";
+  }
+
+  if (isYtdlpFailureStatus(normalized)) {
+    return "Failed";
+  }
+
+  return "Processing";
+}


### PR DESCRIPTION
## Description
Expand the yt-dlp tool from a YouTube-only flow into a broader multi-site downloader experience. This adds live job progress handling, a supported-sites browser, and related UI and dependency updates to improve download status visibility and platform discoverability.[file:1]

**Key additions:**
- Add multi-site downloader copy and validation so the tool accepts general video URLs instead of only YouTube links.
- Add SSE-based job progress streaming with polling fallback, snapshot parsing, and terminal-state normalization for yt-dlp jobs
- Add response dock progress bar UI and downloading/success state styling for clearer status feedback during long-running jobs
- Add supported-sites dialog, search, and API client method to fetch and preview available download providers.[file:1]
- Remove inline reCAPTCHA script injection from the Astro config component and move script loading into the captcha manager
- Update package and lockfile dependencies, including wrangler, rollup, astro-eslint-parser, and typescript-eslint versions
## Types of changes
- [x] Feature

## Checklist
- [ ] Updated ChangeLog
- [x] Updated UI text and tool labels to reflect multi-site support.[file:1]
- [x] Added new frontend modules for progress monitoring and supported-sites browsing.[file:1]
- [ ] Added or updated tests
- [ ] Reviewed breaking changes and downstream expectations

