### PR TITLE
[feat(ui)] add browser download progress state and unified response tones

### DIFF
--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -350,8 +350,13 @@ const defaultTool = TOOL_CATALOG.find(
   }
 
   #tool-view-panel[data-response-state="downloading"] {
-    border-color: color-mix(in oklab, #f59e0b 70%, var(--border));
-    box-shadow: 0 0 0 1px color-mix(in oklab, #f59e0b 38%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 70%, var(--border));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 38%, transparent);
+  }
+
+  #tool-view-panel[data-response-state="browser-downloading"] {
+    border-color: color-mix(in oklab, var(--accent) 78%, var(--border));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 44%, transparent);
   }
 
   #tool-view-panel[data-response-state="success"] {

--- a/src/scripts/tools/ui/progressBar.ts
+++ b/src/scripts/tools/ui/progressBar.ts
@@ -17,6 +17,8 @@ export type ToolProgressBar = {
 };
 
 const DEFAULT_META = "Waiting for progress...";
+const INDETERMINATE_WIDTH = 38;
+const INDETERMINATE_CLASS = "animate-pulse";
 
 export function createToolProgressBar(
   refs: ToolProgressBarRefs
@@ -36,15 +38,18 @@ export function createToolProgressBar(
 
   const applyPercent = (percent: number | null): void => {
     if (percent === null) {
-      if (lastPercent === null) {
-        return;
-      }
-
-      refs.barEl.style.width = "0%";
+      refs.barEl.classList.add(INDETERMINATE_CLASS);
+      refs.barEl.style.width = `${INDETERMINATE_WIDTH}%`;
       refs.barEl.setAttribute("aria-valuenow", "0");
       lastPercent = null;
-      peakPercent = 0;
+      peakPercent = INDETERMINATE_WIDTH;
       return;
+    }
+
+    refs.barEl.classList.remove(INDETERMINATE_CLASS);
+
+    if (lastPercent === null) {
+      peakPercent = 0;
     }
 
     const clamped = Math.max(0, Math.min(100, percent));
@@ -64,6 +69,7 @@ export function createToolProgressBar(
 
   const reset = (): void => {
     refs.wrapEl.classList.add("hidden");
+    refs.barEl.classList.remove(INDETERMINATE_CLASS);
     refs.barEl.style.width = "0%";
     refs.barEl.setAttribute("aria-valuenow", "0");
     refs.metaEl.textContent = DEFAULT_META;

--- a/src/scripts/tools/ui/responseDock.ts
+++ b/src/scripts/tools/ui/responseDock.ts
@@ -4,6 +4,7 @@ export type ToolResponseState =
   | "idle"
   | "pending"
   | "downloading"
+  | "browser-downloading"
   | "success"
   | "fail"
   | "disabled";
@@ -13,33 +14,55 @@ type ToolResponseDockOptions = {
   hiddenOnIdle?: boolean;
   onStateChange?: (state: ToolResponseState) => void;
   minStateDurationMs?: number;
+  progressVariant?: "bar" | "meta";
 };
 
-const TOOL_RESPONSE_STATE_STYLE: Record<ToolResponseState, string> = {
-  idle: "border-border/70 bg-muted/20 text-foreground/85",
-  pending: "border-amber-500/60 bg-amber-500/10 text-amber-300",
-  downloading: "border-amber-500/70 bg-amber-500/14 text-amber-300",
-  success: "border-emerald-500/60 bg-emerald-500/10 text-emerald-300",
-  fail: "border-rose-500/60 bg-rose-500/10 text-rose-300",
-  disabled: "border-slate-500/60 bg-slate-500/10 text-slate-300",
+type ToolResponseTone = {
+  containerClass: string;
+  progressClass: string;
 };
+
+const DEFAULT_TOOL_RESPONSE_TONES: Record<ToolResponseState, ToolResponseTone> =
+  {
+    idle: {
+      containerClass: "border-border/70 bg-muted/20 text-foreground/85",
+      progressClass: "bg-foreground/35",
+    },
+    pending: {
+      containerClass: "border-amber-500/60 bg-amber-500/10 text-amber-300",
+      progressClass: "bg-amber-400",
+    },
+    downloading: {
+      containerClass: "border-accent/70 bg-accent/10 text-accent",
+      progressClass: "bg-accent",
+    },
+    "browser-downloading": {
+      containerClass: "border-accent/80 bg-accent/14 text-accent",
+      progressClass: "bg-accent",
+    },
+    success: {
+      containerClass:
+        "border-emerald-500/60 bg-emerald-500/10 text-emerald-300",
+      progressClass: "bg-emerald-400",
+    },
+    fail: {
+      containerClass: "border-rose-500/60 bg-rose-500/10 text-rose-300",
+      progressClass: "bg-rose-400",
+    },
+    disabled: {
+      containerClass: "border-slate-500/60 bg-slate-500/10 text-slate-300",
+      progressClass: "bg-slate-400",
+    },
+  };
 
 const TOOL_RESPONSE_STATE_LABEL: Record<ToolResponseState, string> = {
   idle: "Ready",
   pending: "Pending",
   downloading: "Downloading",
+  "browser-downloading": "Saving",
   success: "Success",
   fail: "Failed",
   disabled: "Disabled",
-};
-
-const TOOL_PROGRESS_BAR_STYLE: Record<ToolResponseState, string> = {
-  idle: "bg-foreground/35",
-  pending: "bg-amber-400",
-  downloading: "bg-amber-400",
-  success: "bg-emerald-400",
-  fail: "bg-rose-400",
-  disabled: "bg-slate-400",
 };
 
 export type ToolResponseDock = {
@@ -49,6 +72,7 @@ export type ToolResponseDock = {
     options?: { showWhenIdle?: boolean }
   ) => void;
   setProgress: (percent: number | null, meta: string) => void;
+  setProgressMeta: (meta: string) => void;
   clearProgress: () => void;
   getState: () => ToolResponseState;
   hide: () => void;
@@ -62,10 +86,29 @@ export function createToolResponseDock(
   const title = options?.title ?? "Response";
   const hiddenOnIdle = options?.hiddenOnIdle ?? true;
   const minStateDurationMs = options?.minStateDurationMs ?? 180;
+  const progressVariant = options?.progressVariant ?? "bar";
+  const tones = DEFAULT_TOOL_RESPONSE_TONES;
+
+  const progressInnerMarkup =
+    progressVariant === "bar"
+      ? `
+        <div class="h-2 w-full overflow-hidden rounded-full bg-current/15">
+          <div
+            id="tool-response-progress-bar"
+            class="h-full w-0 rounded-full ${tones.idle.progressClass} transition-[width] duration-200 ease-linear"
+            role="progressbar"
+            aria-label="Task progress"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="0"
+          ></div>
+        </div>
+      `
+      : "";
 
   host.classList.remove("hidden");
   host.innerHTML = `
-    <section id="tool-response-status" class="rounded-2xl border px-3 py-2 text-sm transition-colors ${TOOL_RESPONSE_STATE_STYLE.idle}" aria-live="polite">
+    <section id="tool-response-status" class="rounded-2xl border px-3 py-2 text-sm transition-colors ${tones.idle.containerClass}" aria-live="polite">
       <div class="flex items-center gap-2 text-xs opacity-85">
         <span class="h-px flex-1 bg-current/40"></span>
         <span class="font-semibold tracking-wide uppercase">${title}</span>
@@ -89,17 +132,7 @@ export function createToolResponseDock(
         <div class="mb-1 text-[11px] opacity-80">
           <span id="tool-response-progress-meta" class="block truncate">Waiting for progress...</span>
         </div>
-        <div class="h-2 w-full overflow-hidden rounded-full bg-current/15">
-          <div
-            id="tool-response-progress-bar"
-            class="h-full w-0 rounded-full ${TOOL_PROGRESS_BAR_STYLE.idle} transition-[width] duration-200 ease-linear"
-            role="progressbar"
-            aria-label="Task progress"
-            aria-valuemin="0"
-            aria-valuemax="100"
-            aria-valuenow="0"
-          ></div>
-        </div>
+        ${progressInnerMarkup}
       </div>
     </section>
   `;
@@ -132,12 +165,13 @@ export function createToolResponseDock(
     !messageEl ||
     !dismissBtn ||
     !progressWrapEl ||
-    !progressBarEl ||
-    !progressMetaEl
+    !progressMetaEl ||
+    (progressVariant === "bar" && !progressBarEl)
   ) {
     return {
       setState: () => {},
       setProgress: () => {},
+      setProgressMeta: () => {},
       clearProgress: () => {},
       getState: () => "idle",
       hide: () => host.classList.add("hidden"),
@@ -157,22 +191,57 @@ export function createToolResponseDock(
     showWhenIdle: boolean;
   } | null = null;
 
-  const progressBar = createToolProgressBar({
-    wrapEl: progressWrapEl,
-    barEl: progressBarEl,
-    metaEl: progressMetaEl,
-  });
+  const progressToneClasses = Array.from(
+    new Set(Object.values(tones).map(tone => tone.progressClass))
+  );
+
+  let lastPercent: number | null = null;
+
+  const barProgress =
+    progressVariant === "bar" && progressBarEl
+      ? createToolProgressBar({
+          wrapEl: progressWrapEl,
+          barEl: progressBarEl,
+          metaEl: progressMetaEl,
+        })
+      : null;
 
   const applyProgressTone = (state: ToolResponseState): void => {
-    progressBarEl.classList.remove(
-      TOOL_PROGRESS_BAR_STYLE.idle,
-      TOOL_PROGRESS_BAR_STYLE.pending,
-      TOOL_PROGRESS_BAR_STYLE.downloading,
-      TOOL_PROGRESS_BAR_STYLE.success,
-      TOOL_PROGRESS_BAR_STYLE.fail,
-      TOOL_PROGRESS_BAR_STYLE.disabled
-    );
-    progressBarEl.classList.add(TOOL_PROGRESS_BAR_STYLE[state]);
+    if (!progressBarEl) {
+      return;
+    }
+
+    progressBarEl.classList.remove(...progressToneClasses);
+    progressBarEl.classList.add(tones[state].progressClass);
+  };
+
+  const resetProgress = (): void => {
+    if (barProgress) {
+      barProgress.reset();
+    } else {
+      progressWrapEl.classList.add("hidden");
+      progressMetaEl.textContent = "Waiting for progress...";
+      lastPercent = null;
+    }
+  };
+
+  const updateProgress = (percent: number | null, meta: string): void => {
+    if (barProgress) {
+      barProgress.update({ percent, meta });
+      return;
+    }
+
+    progressWrapEl.classList.remove("hidden");
+    progressMetaEl.textContent = meta || "Waiting for progress...";
+    lastPercent = percent;
+  };
+
+  const getProgressPercent = (): number | null => {
+    if (barProgress) {
+      return barProgress.getPercent();
+    }
+
+    return lastPercent;
   };
 
   const setVisible = (visible: boolean) => {
@@ -186,13 +255,17 @@ export function createToolResponseDock(
   ) => {
     currentState = state;
     lastStateChangeAt = Date.now();
-    statusEl.className = `rounded-2xl border px-3 py-2 text-sm transition-colors ${TOOL_RESPONSE_STATE_STYLE[state]}`;
+    statusEl.className = `rounded-2xl border px-3 py-2 text-sm transition-colors ${tones[state].containerClass}`;
     labelEl.textContent = TOOL_RESPONSE_STATE_LABEL[state];
     messageEl.textContent = message;
     applyProgressTone(state);
 
-    if (state !== "pending" && state !== "downloading") {
-      progressBar.reset();
+    if (
+      state !== "pending" &&
+      state !== "downloading" &&
+      state !== "browser-downloading"
+    ) {
+      resetProgress();
     }
 
     const persist = state === "disabled";
@@ -206,11 +279,15 @@ export function createToolResponseDock(
   };
 
   const setProgress: ToolResponseDock["setProgress"] = (percent, meta) => {
-    progressBar.update({ percent, meta });
+    updateProgress(percent, meta);
+  };
+
+  const setProgressMeta: ToolResponseDock["setProgressMeta"] = meta => {
+    updateProgress(getProgressPercent(), meta);
   };
 
   const clearProgress: ToolResponseDock["clearProgress"] = () => {
-    progressBar.reset();
+    resetProgress();
   };
 
   const setState: ToolResponseDock["setState"] = (
@@ -265,6 +342,7 @@ export function createToolResponseDock(
   return {
     setState,
     setProgress,
+    setProgressMeta,
     clearProgress,
     getState: () => currentState,
     hide: () => setVisible(false),
@@ -272,7 +350,7 @@ export function createToolResponseDock(
       if (pendingStateTimer !== null) {
         window.clearTimeout(pendingStateTimer);
       }
-      progressBar.reset();
+      resetProgress();
       host.innerHTML = "";
       host.classList.add("hidden");
       options?.onStateChange?.("idle");

--- a/src/scripts/tools/ui/responseDock.ts
+++ b/src/scripts/tools/ui/responseDock.ts
@@ -15,6 +15,7 @@ type ToolResponseDockOptions = {
   onStateChange?: (state: ToolResponseState) => void;
   minStateDurationMs?: number;
   progressVariant?: "bar" | "meta";
+  hideProgressBarStates?: ToolResponseState[];
 };
 
 type ToolResponseTone = {
@@ -87,12 +88,13 @@ export function createToolResponseDock(
   const hiddenOnIdle = options?.hiddenOnIdle ?? true;
   const minStateDurationMs = options?.minStateDurationMs ?? 180;
   const progressVariant = options?.progressVariant ?? "bar";
+  const hideProgressBarStates = new Set(options?.hideProgressBarStates ?? []);
   const tones = DEFAULT_TOOL_RESPONSE_TONES;
 
   const progressInnerMarkup =
     progressVariant === "bar"
       ? `
-        <div class="h-2 w-full overflow-hidden rounded-full bg-current/15">
+        <div id="tool-response-progress-track" class="h-2 w-full overflow-hidden rounded-full bg-current/15">
           <div
             id="tool-response-progress-bar"
             class="h-full w-0 rounded-full ${tones.idle.progressClass} transition-[width] duration-200 ease-linear"
@@ -155,6 +157,9 @@ export function createToolResponseDock(
   const progressBarEl = host.querySelector(
     "#tool-response-progress-bar"
   ) as HTMLElement | null;
+  const progressTrackEl = host.querySelector(
+    "#tool-response-progress-track"
+  ) as HTMLElement | null;
   const progressMetaEl = host.querySelector(
     "#tool-response-progress-meta"
   ) as HTMLElement | null;
@@ -166,7 +171,7 @@ export function createToolResponseDock(
     !dismissBtn ||
     !progressWrapEl ||
     !progressMetaEl ||
-    (progressVariant === "bar" && !progressBarEl)
+    (progressVariant === "bar" && (!progressBarEl || !progressTrackEl))
   ) {
     return {
       setState: () => {},
@@ -215,6 +220,16 @@ export function createToolResponseDock(
     progressBarEl.classList.add(tones[state].progressClass);
   };
 
+  const applyProgressTrackVisibility = (state: ToolResponseState): void => {
+    if (!progressTrackEl) {
+      return;
+    }
+
+    const shouldHideTrack =
+      progressVariant !== "bar" || hideProgressBarStates.has(state);
+    progressTrackEl.classList.toggle("hidden", shouldHideTrack);
+  };
+
   const resetProgress = (): void => {
     if (barProgress) {
       barProgress.reset();
@@ -259,6 +274,7 @@ export function createToolResponseDock(
     labelEl.textContent = TOOL_RESPONSE_STATE_LABEL[state];
     messageEl.textContent = message;
     applyProgressTone(state);
+    applyProgressTrackVisibility(state);
 
     if (
       state !== "pending" &&

--- a/src/scripts/tools/ytdlp/apiClient.ts
+++ b/src/scripts/tools/ytdlp/apiClient.ts
@@ -428,9 +428,7 @@ export class YtdlpApiClient extends CoreApiClient {
             continue;
           }
 
-          const chunk = new Uint8Array(value.byteLength);
-          chunk.set(value);
-          chunks.push(chunk);
+          chunks.push(value);
           loadedBytes += value.byteLength;
 
           const elapsedSeconds = Math.max(

--- a/src/scripts/tools/ytdlp/apiClient.ts
+++ b/src/scripts/tools/ytdlp/apiClient.ts
@@ -18,6 +18,17 @@ export type YtdlpDownloadFile = {
   fileName: string;
 };
 
+export type YtdlpBrowserDownloadProgress = {
+  loadedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+  bytesPerSecond: number | null;
+};
+
+type YtdlpDownloadOptions = {
+  onProgress?: (progress: YtdlpBrowserDownloadProgress) => void;
+};
+
 export type YtdlpJobSnapshot = {
   status: string;
   progressPercent: number | null;
@@ -352,7 +363,8 @@ export class YtdlpApiClient extends CoreApiClient {
 
   async downloadFile(
     jobId: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options?: YtdlpDownloadOptions
   ): Promise<ApiResult<YtdlpDownloadFile>> {
     try {
       const response = await fetch(
@@ -367,7 +379,85 @@ export class YtdlpApiClient extends CoreApiClient {
         return this.errorResultFromStatus(response.status);
       }
 
-      const blob = await response.blob();
+      const totalBytesHeader = response.headers.get("content-length");
+      const parsedTotalBytes = totalBytesHeader
+        ? Number.parseInt(totalBytesHeader, 10)
+        : Number.NaN;
+      const totalBytes =
+        Number.isFinite(parsedTotalBytes) && parsedTotalBytes > 0
+          ? parsedTotalBytes
+          : null;
+
+      const onProgress = options?.onProgress;
+      const reader = response.body?.getReader();
+
+      let blob: Blob;
+
+      if (!reader) {
+        blob = await response.blob();
+        onProgress?.({
+          loadedBytes: blob.size,
+          totalBytes,
+          percent:
+            totalBytes && totalBytes > 0
+              ? Math.max(0, Math.min(100, (blob.size / totalBytes) * 100))
+              : null,
+          bytesPerSecond: null,
+        });
+      } else {
+        const contentType = response.headers.get("content-type") ?? undefined;
+        const chunks: BlobPart[] = [];
+        let loadedBytes = 0;
+        const startedAt = performance.now();
+
+        onProgress?.({
+          loadedBytes,
+          totalBytes,
+          percent: totalBytes ? 0 : null,
+          bytesPerSecond: null,
+        });
+
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            break;
+          }
+
+          if (!value) {
+            continue;
+          }
+
+          const chunk = new Uint8Array(value.byteLength);
+          chunk.set(value);
+          chunks.push(chunk);
+          loadedBytes += value.byteLength;
+
+          const elapsedSeconds = Math.max(
+            (performance.now() - startedAt) / 1000,
+            0.001
+          );
+          const bytesPerSecond = loadedBytes / elapsedSeconds;
+
+          onProgress?.({
+            loadedBytes,
+            totalBytes,
+            percent:
+              totalBytes && totalBytes > 0
+                ? Math.max(0, Math.min(100, (loadedBytes / totalBytes) * 100))
+                : null,
+            bytesPerSecond: Number.isFinite(bytesPerSecond)
+              ? bytesPerSecond
+              : null,
+          });
+        }
+
+        blob = new Blob(
+          chunks,
+          contentType ? { type: contentType } : undefined
+        );
+      }
+
       const contentDisposition = response.headers.get("content-disposition");
       const fileName =
         this.extractFileName(contentDisposition) ?? `${jobId}.mp4`;

--- a/src/scripts/tools/ytdlp/controller.ts
+++ b/src/scripts/tools/ytdlp/controller.ts
@@ -111,7 +111,8 @@ export class YtdlpToolController {
       title: "AIO Downloader Response",
       hiddenOnIdle: true,
       minStateDurationMs: 220,
-      progressVariant: "meta",
+      progressVariant: "bar",
+      hideProgressBarStates: ["browser-downloading"],
       onStateChange: state => {
         if (this.toolViewPanel) {
           this.toolViewPanel.dataset.responseState = state;
@@ -490,13 +491,13 @@ export class YtdlpToolController {
 
     this.ui.setPrimaryStage("pending");
     this.ui.transition("BROWSER_DOWNLOADING", "Saving file to your browser...");
+    this.ui.setPendingProgress("Saving to browser", null);
 
     const downloadResult = await this.apiClient.downloadFile(
       this.readyJobId,
       signal,
       {
         onProgress: progress => {
-          this.ui.setPendingProgress("Saving to browser", null);
           this.ui.setPendingDetails(formatBrowserDownloadMeta(progress));
         },
       }
@@ -525,7 +526,7 @@ export class YtdlpToolController {
     this.ui.setPrimaryStage("submit");
     this.ui.transition(
       "READY",
-      "Saved to browser downloads. You can start another download."
+      "Download Complete! Paste another URL to download more media."
     );
   }
 

--- a/src/scripts/tools/ytdlp/controller.ts
+++ b/src/scripts/tools/ytdlp/controller.ts
@@ -2,7 +2,7 @@ import { createToolResponseDock } from "../ui/responseDock";
 import { readClipboardText } from "../clipboard";
 import type { ToolTeardown, YtdlpToolOptions } from "../types";
 import { validateYtdlpActionInput } from "./validation";
-import type { YtdlpApiClient } from "./apiClient";
+import type { YtdlpApiClient, YtdlpBrowserDownloadProgress } from "./apiClient";
 import { CaptchaManager } from "../../../utils/captchaManager";
 import type { ApiErrorType, ApiResult } from "../../../utils/CoreApiClient";
 import type { YtdlpDomRefs } from "./dom";
@@ -15,6 +15,43 @@ const SERVICE_UNAVAILABLE_MESSAGE =
   "Download service is currently unavailable due to maintenance. Please try again later.";
 const SERVICE_UNREACHABLE_MESSAGE =
   "Download service is currently unreachable. It may be under maintenance. Please try again later.";
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value < 0) {
+    return "0 B";
+  }
+
+  if (value < 1024) {
+    return `${Math.round(value)} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = value / 1024;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function formatBrowserDownloadMeta(
+  progress: YtdlpBrowserDownloadProgress
+): string {
+  const transferredText = `Transferred ${formatBytes(progress.loadedBytes)}`;
+  const sizeText =
+    typeof progress.totalBytes === "number"
+      ? `${transferredText} of ${formatBytes(progress.totalBytes)}`
+      : transferredText;
+  const speedText =
+    typeof progress.bytesPerSecond === "number" && progress.bytesPerSecond > 0
+      ? `Speed ${formatBytes(progress.bytesPerSecond)}/s`
+      : "Speed calculating...";
+
+  return `${sizeText} • ${speedText}`;
+}
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
@@ -74,6 +111,7 @@ export class YtdlpToolController {
       title: "AIO Downloader Response",
       hiddenOnIdle: true,
       minStateDurationMs: 220,
+      progressVariant: "meta",
       onStateChange: state => {
         if (this.toolViewPanel) {
           this.toolViewPanel.dataset.responseState = state;
@@ -90,6 +128,9 @@ export class YtdlpToolController {
         },
         setDockProgress: (percent, meta) => {
           this.responseDock.setProgress(percent, meta);
+        },
+        setDockProgressMeta: meta => {
+          this.responseDock.setProgressMeta(meta);
         },
         clearDockProgress: () => {
           this.responseDock.clearProgress();
@@ -135,7 +176,7 @@ export class YtdlpToolController {
   handleCaptchaSolved(): void {
     this.ui.transition(
       "AWAITING_CAPTCHA",
-      "Captcha solved. Click Verify and Continue.",
+      "Verification completed. Click Verify and Continue to start processing.",
       {
         showWhenIdle: true,
       }
@@ -143,11 +184,14 @@ export class YtdlpToolController {
   }
 
   handleCaptchaExpired(): void {
-    this.ui.transition("ERROR", "Captcha expired. Please solve it again.");
+    this.ui.transition(
+      "ERROR",
+      "Verification expired. Please complete captcha again."
+    );
   }
 
   handleCaptchaError(): void {
-    this.ui.transition("ERROR", "Captcha error. Please try again.");
+    this.ui.transition("ERROR", "Verification failed to load. Please retry.");
   }
 
   private bindEvents(): void {
@@ -187,7 +231,7 @@ export class YtdlpToolController {
       case "RATE_LIMITED":
         this.ui.transition(
           "ERROR",
-          "Too many requests. Please wait before trying again."
+          "Too many requests right now. Please wait and try again."
         );
         return "handled";
 
@@ -198,7 +242,7 @@ export class YtdlpToolController {
 
         this.ui.transition(
           "ERROR",
-          "Verification failed. Please retry captcha and submit again."
+          "Verification was rejected. Complete captcha again and resubmit."
         );
         return "handled";
 
@@ -206,7 +250,7 @@ export class YtdlpToolController {
         this.ui.transition(
           "ERROR",
           result.message ||
-            "Invalid request. Please check the input and try again."
+            "The request is invalid. Check the URL and try again."
         );
         return "handled";
 
@@ -214,7 +258,7 @@ export class YtdlpToolController {
       default:
         this.ui.transition(
           "ERROR",
-          result.message || "Request failed. Please try again."
+          result.message || "The request failed unexpectedly. Please try again."
         );
         return "handled";
     }
@@ -224,11 +268,6 @@ export class YtdlpToolController {
     const stage = this.ui.getPrimaryStage();
 
     if (stage === "pending") {
-      return;
-    }
-
-    if (stage === "download" && this.readyJobId) {
-      await this.handleDownloadClick();
       return;
     }
 
@@ -283,7 +322,7 @@ export class YtdlpToolController {
         if (!signal.aborted) {
           this.ui.transition(
             "ERROR",
-            "Verification failed to load. Refresh and try again."
+            "Unable to load verification. Refresh and try again."
           );
         }
         return;
@@ -291,7 +330,7 @@ export class YtdlpToolController {
 
       this.ui.transition(
         "AWAITING_CAPTCHA",
-        "Solve captcha and verify to continue.",
+        "Complete captcha, then click Verify and Continue.",
         {
           showWhenIdle: true,
         }
@@ -300,7 +339,7 @@ export class YtdlpToolController {
       if (!isAbortError(error)) {
         this.ui.transition(
           "ERROR",
-          "Verification failed to load. Refresh and try again."
+          "Unable to load verification. Refresh and try again."
         );
       }
     }
@@ -346,7 +385,7 @@ export class YtdlpToolController {
     const captchaToken = captchaValidation.normalized?.captchaToken ?? "";
 
     try {
-      this.ui.transition("SUBMITTING", "Starting download...");
+      this.ui.transition("SUBMITTING", "Submitting URL to server...");
 
       const enqueueResult = await apiClient.enqueue(
         urlValidation.normalized?.url ?? "",
@@ -376,14 +415,14 @@ export class YtdlpToolController {
       this.readyJobId = null;
       this.jobMonitor.resetProgressKey();
       this.ui.setPrimaryStage("pending");
-      this.ui.setPendingProgress("Queued", null);
+      this.ui.setPendingProgress("Server queue", null);
       this.ui.transition(
-        "POLLING",
-        "Download started. Waiting for progress..."
+        "SERVER_DOWNLOADING",
+        "Server accepted your request. Preparing media..."
       );
 
       const result = await this.jobMonitor.monitorJob(jobId, signal);
-      this.applyMonitorResult(result, jobId);
+      await this.applyMonitorResult(result, jobId);
     } catch (error) {
       if (!isAbortError(error)) {
         this.readyJobId = null;
@@ -392,20 +431,30 @@ export class YtdlpToolController {
     }
   }
 
-  private applyMonitorResult(result: StreamMonitorResult, jobId: string): void {
+  private async applyMonitorResult(
+    result: StreamMonitorResult,
+    jobId: string
+  ): Promise<void> {
     this.jobMonitor.resetProgressKey();
 
     if (result === "success") {
       this.readyJobId = jobId;
-      this.ui.setPrimaryStage("download");
-      this.ui.transition("READY", "Download is ready.");
+      this.ui.setPrimaryStage("pending");
+      this.ui.transition(
+        "BROWSER_DOWNLOADING",
+        "Server processing complete. Starting browser download..."
+      );
+      await this.handleDownloadClick();
       return;
     }
 
     if (result === "fail") {
       this.readyJobId = null;
       this.ui.setPrimaryStage("submit");
-      this.ui.transition("ERROR", "Download failed. Try another URL.");
+      this.ui.transition(
+        "ERROR",
+        "Server could not prepare this video. Try a different URL."
+      );
       return;
     }
 
@@ -418,7 +467,7 @@ export class YtdlpToolController {
     this.ui.setPrimaryStage("submit");
     this.ui.transition(
       "ERROR",
-      "Download is taking longer than expected. Please try again."
+      "Server processing is taking too long. Please try again later."
     );
   }
 
@@ -430,17 +479,27 @@ export class YtdlpToolController {
 
     if (!this.apiClient || !this.readyJobId) {
       this.ui.setPrimaryStage("submit");
-      this.ui.transition("ERROR", "Download is no longer ready. Submit again.");
+      this.ui.transition(
+        "ERROR",
+        "Download session expired. Submit the URL again."
+      );
       return;
     }
 
     const signal = this.beginOperation();
 
-    this.ui.transition("SUBMITTING", "Preparing file download...");
+    this.ui.setPrimaryStage("pending");
+    this.ui.transition("BROWSER_DOWNLOADING", "Saving file to your browser...");
 
     const downloadResult = await this.apiClient.downloadFile(
       this.readyJobId,
-      signal
+      signal,
+      {
+        onProgress: progress => {
+          this.ui.setPendingProgress("Saving to browser", null);
+          this.ui.setPendingDetails(formatBrowserDownloadMeta(progress));
+        },
+      }
     );
 
     if (!downloadResult.ok) {
@@ -464,7 +523,10 @@ export class YtdlpToolController {
 
     this.readyJobId = null;
     this.ui.setPrimaryStage("submit");
-    this.ui.transition("READY", "Download started.");
+    this.ui.transition(
+      "READY",
+      "Saved to browser downloads. You can start another download."
+    );
   }
 
   private triggerBrowserDownload(blob: Blob, fileName: string): void {
@@ -494,7 +556,7 @@ export class YtdlpToolController {
 
     const signal = this.beginOperation();
 
-    this.ui.transition("SUBMITTING", "Reading from clipboard...");
+    this.ui.transition("SUBMITTING", "Reading URL from clipboard...");
 
     const result = await readClipboardText();
     if (signal.aborted || this.disposed) {
@@ -506,17 +568,20 @@ export class YtdlpToolController {
         this.refs.inputEl.focus();
         this.ui.transition(
           "ERROR",
-          "Clipboard access is unavailable. Focused URL field—press Ctrl+V to paste."
+          "Clipboard access is unavailable. URL field is focused. Press Ctrl+V to paste."
         );
         return;
       }
 
-      this.ui.transition("ERROR", "Clipboard read failed.");
+      this.ui.transition(
+        "ERROR",
+        "Could not read clipboard. Please paste manually."
+      );
       return;
     }
 
     this.refs.inputEl.value = result.text;
-    this.ui.transition("READY", "Pasted from clipboard.");
+    this.ui.transition("READY", "URL pasted from clipboard.");
   }
 
   private clearForm(): void {
@@ -528,7 +593,7 @@ export class YtdlpToolController {
     this.ui.setPrimaryStage("submit");
     this.captchaDialog.close();
     this.captchaManager?.reset();
-    this.ui.transition("READY", "Fields cleared.");
+    this.ui.transition("READY", "Form reset. Ready for a new URL.");
   }
 
   private async ensureServiceHealth(): Promise<void> {

--- a/src/scripts/tools/ytdlp/jobMonitor.ts
+++ b/src/scripts/tools/ytdlp/jobMonitor.ts
@@ -72,7 +72,7 @@ export class YtdlpJobMonitor {
 
     this.ui.setPendingProgress(label, snapshot.progressPercent);
     this.ui.setPendingDetails(buildYtdlpProgressMeta(snapshot));
-    this.ui.transition("POLLING", message);
+    this.ui.transition("SERVER_DOWNLOADING", message);
   }
 
   private async monitorJobWithStream(
@@ -110,7 +110,10 @@ export class YtdlpJobMonitor {
         onError: error => {
           if (settled || signal.aborted) return;
           if (error.shouldFallbackToPolling) {
-            this.ui.transition("POLLING", error.message);
+            this.ui.transition(
+              "SERVER_DOWNLOADING",
+              "Live server updates were interrupted. Switching to status checks..."
+            );
             settle("fallback");
             return;
           }
@@ -152,11 +155,14 @@ export class YtdlpJobMonitor {
     if (!this.apiClient) return "handled-error";
 
     const apiClient = this.apiClient;
-    this.ui.setPendingProgress("Checking", null);
+    this.ui.setPendingProgress("Server status", null);
     this.ui.setPendingDetails(
-      "Progress stream is unavailable. Falling back to polling."
+      "Live progress is unavailable. Checking server status every few seconds."
     );
-    this.ui.transition("POLLING", "Checking download status...");
+    this.ui.transition(
+      "SERVER_DOWNLOADING",
+      "Checking server processing status..."
+    );
 
     const result = await asyncPoll<"success" | "fail" | "handled-error">({
       intervalMs: POLL_INTERVAL_MS,

--- a/src/scripts/tools/ytdlp/uiController.ts
+++ b/src/scripts/tools/ytdlp/uiController.ts
@@ -6,12 +6,13 @@ export type YtdlpUiState =
   | "AWAITING_CAPTCHA"
   | "LOADING_CAPTCHA"
   | "SUBMITTING"
-  | "POLLING"
+  | "SERVER_DOWNLOADING"
+  | "BROWSER_DOWNLOADING"
   | "READY"
   | "ERROR"
   | "DISABLED";
 
-export type PrimaryStage = "submit" | "pending" | "download";
+export type PrimaryStage = "submit" | "pending";
 
 type ResponseBridge = {
   setDockState: (
@@ -20,6 +21,7 @@ type ResponseBridge = {
     options?: { showWhenIdle?: boolean }
   ) => void;
   setDockProgress: (percent: number | null, meta: string) => void;
+  setDockProgressMeta: (meta: string) => void;
   clearDockProgress: () => void;
 };
 
@@ -27,30 +29,6 @@ export class YtdlpUiController {
   private state: YtdlpUiState = "IDLE";
   private primaryStage: PrimaryStage = "submit";
   private pendingPercent: number | null = null;
-
-  private readonly responseToneClasses = [
-    "border-accent",
-    "bg-accent/5",
-    "text-accent",
-    "hover:bg-accent",
-    "hover:text-white",
-    "border-amber-500",
-    "bg-amber-500/10",
-    "text-amber-300",
-    "hover:bg-amber-500",
-    "border-green-600",
-    "bg-green-600",
-    "text-white",
-    "hover:bg-green-700",
-    "border-rose-500",
-    "bg-rose-500/10",
-    "text-rose-300",
-    "hover:bg-rose-500",
-    "border-slate-500",
-    "bg-slate-500/10",
-    "text-slate-300",
-    "hover:bg-slate-500",
-  ] as const;
 
   constructor(
     private readonly refs: YtdlpDomRefs,
@@ -68,62 +46,6 @@ export class YtdlpUiController {
   private renderProgressBar(percent: number | null, meta: string): void {
     this.pendingPercent = percent;
     this.responseState.setDockProgress(percent, meta);
-  }
-
-  private applySubmitButtonTone(state: ToolResponseState): void {
-    const submitBtn = this.refs.submitBtn;
-    submitBtn.classList.remove(...this.responseToneClasses);
-
-    if (state === "idle") {
-      submitBtn.classList.add(
-        "border-accent",
-        "bg-accent/5",
-        "text-accent",
-        "hover:bg-accent",
-        "hover:text-white"
-      );
-      return;
-    }
-
-    if (state === "pending" || state === "downloading") {
-      submitBtn.classList.add(
-        "border-amber-500",
-        "bg-amber-500/10",
-        "text-amber-300",
-        "hover:bg-amber-500",
-        "hover:text-white"
-      );
-      return;
-    }
-
-    if (state === "success") {
-      submitBtn.classList.add(
-        "border-green-600",
-        "bg-green-600",
-        "text-white",
-        "hover:bg-green-700"
-      );
-      return;
-    }
-
-    if (state === "fail") {
-      submitBtn.classList.add(
-        "border-rose-500",
-        "bg-rose-500/10",
-        "text-rose-300",
-        "hover:bg-rose-500",
-        "hover:text-white"
-      );
-      return;
-    }
-
-    submitBtn.classList.add(
-      "border-slate-500",
-      "bg-slate-500/10",
-      "text-slate-300",
-      "hover:bg-slate-500",
-      "hover:text-white"
-    );
   }
 
   setPendingProgress(label: string, percent: number | null): void {
@@ -146,7 +68,7 @@ export class YtdlpUiController {
       return;
     }
 
-    this.renderProgressBar(this.pendingPercent, details);
+    this.responseState.setDockProgressMeta(details);
   }
 
   setPrimaryStage(stage: PrimaryStage): void {
@@ -157,19 +79,6 @@ export class YtdlpUiController {
     if (stage === "submit") {
       this.hideProgress();
       submitBtn.textContent = "Submit Download";
-      submitBtn.classList.remove(
-        "bg-green-600",
-        "border-green-600",
-        "text-white",
-        "hover:bg-green-700"
-      );
-      submitBtn.classList.add(
-        "border-accent",
-        "bg-accent/5",
-        "text-accent",
-        "hover:bg-accent",
-        "hover:text-white"
-      );
       return;
     }
 
@@ -178,9 +87,6 @@ export class YtdlpUiController {
       this.renderProgressBar(null, "Waiting for progress...");
       return;
     }
-
-    submitBtn.textContent = "Save File";
-    this.hideProgress();
   }
 
   getPrimaryStage(): PrimaryStage {
@@ -197,8 +103,10 @@ export class YtdlpUiController {
     let dockState: ToolResponseState = "idle";
     if (nextState === "LOADING_CAPTCHA" || nextState === "SUBMITTING") {
       dockState = "pending";
-    } else if (nextState === "POLLING") {
+    } else if (nextState === "SERVER_DOWNLOADING") {
       dockState = "downloading";
+    } else if (nextState === "BROWSER_DOWNLOADING") {
+      dockState = "browser-downloading";
     } else if (nextState === "READY") {
       dockState = "success";
     } else if (nextState === "ERROR") {
@@ -208,7 +116,6 @@ export class YtdlpUiController {
     }
 
     this.responseState.setDockState(dockState, message, options);
-    this.applySubmitButtonTone(dockState);
     this.syncInteractiveState();
   }
 
@@ -219,14 +126,16 @@ export class YtdlpUiController {
   syncInteractiveState(): void {
     const isBusy =
       this.state === "LOADING_CAPTCHA" || this.state === "SUBMITTING";
-    const isPolling = this.state === "POLLING";
+    const isDownloading =
+      this.state === "SERVER_DOWNLOADING" ||
+      this.state === "BROWSER_DOWNLOADING";
     const isDisabled = this.state === "DISABLED";
 
     this.refs.pasteBtn.disabled = isBusy;
     this.refs.clearBtn.disabled = isBusy;
 
     this.refs.submitBtn.disabled =
-      isDisabled || isBusy || isPolling || !this.isCaptchaEnabled;
+      isDisabled || isBusy || isDownloading || !this.isCaptchaEnabled;
 
     if (this.primaryStage === "pending") {
       this.refs.submitBtn.disabled = true;


### PR DESCRIPTION
## Description
This updates the downloader flow to distinguish server-side processing from browser-side saving and improves how progress and status are shown in the response dock. It also refines UI messaging and replaces hardcoded download styling with accent-based tones for a more consistent experience.

**Key additions:**
- Add a dedicated browser-downloading response state with separate label and styling
- Refactor response dock tone handling to use shared container and progress classes
- Update progress handling to support meta-only progress display and indeterminate browser save state
- Add streamed browser download progress reporting with transferred size and speed metadata
- Fix downloader flow to automatically start browser download after server processing completes
- Update user-facing status and error copy across captcha, queue, download, and clipboard states

## Types of changes
- [x] Feature

## Checklist
- [ ] Updated ChangeLog
- [x] Updated UI state handling for new download phases
- [x] Updated progress reporting for browser download events
- [ ] Added or updated tests
- [ ] Reviewed for breaking changes

