### PR TITLE
[build(ci)] migrate manual deploy workflow to Cloudflare Workers environments

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build Astro
         env:
-          CLOUDFLARE_ENV: production
+          CLOUDFLARE_ENV: ${{ env.DEPLOY_ENVIRONMENT }}
         run: make build
 
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.13.0
-      
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     # if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_me == true
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js
+      - name: Validate user authorization
         run: |
           if [[ -z "${{ vars.AUTHORIZED_USERS }}" ]]; then
             echo "::error::AUTHORIZED_USERS variable not configured"
@@ -38,6 +38,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.13.0
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
 
       - name: Build Astro
         env:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -37,12 +37,14 @@ jobs:
           node-version: 24.13.0
 
       - name: Build Astro
+        env:
+          CLOUDFLARE_ENV: production
         run: make build
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=YOUR_PROJECT_NAME
+          command: deploy --env production
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: boolean
         default: false
+  push:
+    branches:
+      - nadun/migrate-to-cf-workers
 
 env:
   deploy_me: ${{ github.event.inputs.deploy_me }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -3,20 +3,20 @@ name: Deploy Portfolio Manually
 on:
   workflow_dispatch:
     inputs:
-      deploy_me:
-        description: "Deploy Portfolio?"
+      deploy_environment:
+        description: "Choose deployment environment"
         required: true
-        type: boolean
-        default: false
-  push:
-    branches:
-      - nadun/migrate-to-cf-workers
+        type: choice
+        options:
+          - preview
+          - production
+        default: preview
 
 env:
-  deploy_me: ${{ github.event.inputs.deploy_me }}
+  DEPLOY_ENVIRONMENT: ${{ github.event.inputs.deploy_environment }}
 jobs:
   deploy-portfolio:
-    # if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_me == true
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Validate user authorization
@@ -52,5 +52,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env production
+          command: deploy --env ${{ env.DEPLOY_ENVIRONMENT }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -16,7 +16,7 @@ env:
   deploy_me: ${{ github.event.inputs.deploy_me }}
 jobs:
   deploy-portfolio:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_me == true
+    # if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_me == true
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+dist-pages/
 
 # generated types
 .astro/

--- a/Makefile
+++ b/Makefile
@@ -68,19 +68,21 @@ $(DIST_DIR)/.build-timestamp: $(NODE_MODULES)/.install-timestamp $(shell find sr
 	$(SAY) "$(BLUE)Building $(PROJECT_NAME)...$(NC)"
 	$(Q)pnpm run build
 	$(Q)touch $@
-	$(SAY) "$(GREEN)✓ Build completed at $(BUILD_TIME)$(NC)"
+	$(SAY) "$(GREEN) Build completed at $(BUILD_TIME)$(NC)"
 
 preview: $(DIST_DIR)/.build-timestamp ## Preview build (pnpm preview)
 	$(SAY) "$(BLUE)Starting preview...$(NC)"
 	$(Q)pnpm run preview
 
-deploy: guard-production clean install format-check build ## Deploy (pnpm deploy)
+deploy: guard-production clean install format-check ## Deploy (pnpm deploy)
 	$(SAY) "$(GREEN)Deploying $(PROJECT_NAME)...$(NC)"
-	$(Q)pnpm wrangler pages deploy
+	$(Q)CLOUDFLARE_ENV=production pnpm run build
+	$(Q)pnpm wrangler deploy --env production
 
-d-p: build ## Deploy preview branch
+d-p: $(NODE_MODULES)/.install-timestamp ## Deploy preview branch
 	$(SAY) "$(YELLOW)Deploying preview...$(NC)"
-	$(Q)pnpm wrangler pages deploy --branch=$(shell git rev-parse --abbrev-ref HEAD)
+	$(Q)CLOUDFLARE_ENV=preview pnpm run build
+	$(Q)pnpm wrangler deploy --env preview
 
 # -----------------------
 # Code Quality
@@ -103,7 +105,7 @@ lint: ## Lint code (pnpm lint)
 check: ## Run lint and format-check in parallel
 	$(SAY) "$(BLUE)Running checks in parallel ($(NPROCS) threads)...$(NC)"
 	$(Q)$(MAKE) -j$(NPROCS) lint format-check
-	$(SAY) "$(GREEN)✓ All checks passed$(NC)"
+	$(SAY) "$(GREEN) All checks passed$(NC)"
 
 # -----------------------
 # Utilities

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
-  <img src="./public/favicon.svg" alt="Portfolio Logo" width="130" />
-  <h1><code>~/nadzu.me</code> </h1>
-  <p><em>Super Fast Portfolio x Blogger</em></p>
+  <img src="./public/favicon.svg" alt="Portfolio Logo" width="130" />
+  <h1><code>~/nadzu.me</code></h1>
+  <p><em>Fast portfolio with integrated blog</em></p>
 
 [![Old Release](https://img.shields.io/badge/Old%20Release-white.svg)](https://github.com/nxdun/Portfolio/tree/release/1.0.0)
 
@@ -9,42 +9,38 @@
 
 ---
 
-## High Performance
+# Features
 
-![PageSpeed Insights](./public/PageSpeed%20Insights.png)
+Achives Perfect(100/100)
 
-Achieves perfect [PageSpeed mobile scores](https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=mobile) and [PageSpeed Desktop scores](https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=desktop) with heavily chunked CSS and optimized DOM hydration for real-world speed, not just benchmarks.
+- [PageSpeed mobile scores](https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=mobile)
+- [PageSpeed Desktop scores](https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=desktop).
+  ![PageSpeed Insights](./public/PageSpeed%20Insights.png)
 
-## Modular Tool Workspace
+## Tooling Support
 
-A mobile-responsive, built-in developer toolkit:
+- **Quick Execution:** Launch tools via URL query params.
 
-- **YouTube Downloader:** Securely fetch MP4s and Shorts with reCAPTCHA.
-- **Base64 Toolkit:** Fast encoder/decoder with a streamlined UI.
-- **Quick Execution:** Run tools instantly via URL query parameters.
+Built-in tools:
 
-## Integrated Blogger & Showcase
+- [Base64 Encoder/Decoder](https://nadzu.me/tools/?tool=base64) Offline Base64 Encoder and decoder with a clean UI.
 
-Beyond a landing page: a complete Markdown blogging system for changelogs, insights, and a static **Projects** showcase to maximize SEO.
+- [yt-dlp Downloader](https://nadzu.me/tools/?tool=ytdlp) Download from 1,700+ supported sites with reCAPTCHA protection.
 
-## Modern Developer Experience
-
-Rebuilt for stability and ease of use with **Astro + TypeScript**, managed by `pnpm`, and automated with an advanced `Makefile` for parallel tasks and CI/CD.
-
----
+# Development
 
 ## Tech Stack
 
-| Layer          | Tool                                              |
-| -------------- | ------------------------------------------------- |
-| **Framework**  | [Astro](https://astro.build/)                     |
-| **Language**   | [TypeScript](https://www.typescriptlang.org/)     |
-| **Styling**    | [TailwindCSS](https://tailwindcss.com/)           |
-| **Search**     | [Pagefind](https://pagefind.app/)                 |
-| **Icons**      | [Icones](https://icones.js.org/)                  |
-| **Formatting** | [Prettier](https://prettier.io/)                  |
-| **Linting**    | [ESLint](https://eslint.org)                      |
-| **Deployment** | [Cloudflare Pages](https://pages.cloudflare.com/) |
+| Layer          | Tool                                                   |
+| -------------- | ------------------------------------------------------ |
+| **Framework**  | [Astro](https://astro.build/) [pnpm](https://pnpm.io/) |
+| **Language**   | [TypeScript](https://www.typescriptlang.org/)          |
+| **Styling**    | [TailwindCSS](https://tailwindcss.com/)                |
+| **Search**     | [Pagefind](https://pagefind.app/)                      |
+| **Icons**      | [Icones](https://icones.js.org/)                       |
+| **Formatting** | [Prettier](https://prettier.io/)                       |
+| **Linting**    | [ESLint](https://eslint.org)                           |
+| **Deployment** | [Cloudflare Pages](https://pages.cloudflare.com/)      |
 
 ---
 
@@ -83,7 +79,7 @@ choco install make
 |   |-- favicon.svg
 |   |-- nadzu-og-2.jpg
 |   |-- nadzu-og-3.jpg
-|   |-- nadzu-og.jpg
+|   `-- nadzu-og.jpg
 |-- src
 |   |-- assets
 |   |   |-- icons
@@ -162,7 +158,9 @@ choco install make
 |   |   |-- EditPost.astro
 |   |   |-- Footer.astro
 |   |   |-- Header.astro
+|   |   |-- ImageViewer.astro
 |   |   |-- LinkButton.astro
+|   |   |-- Loader
 |   |   |-- Loader.astro
 |   |   |-- Pagination.astro
 |   |   |-- ProjectCard.astro
@@ -184,6 +182,7 @@ choco install make
 |   |   |   |   `-- example-non-draft-non-featured-post.md
 |   |   |   |-- portfolio-changelog-2026.md
 |   |   |   `-- rust-backend-changelog-2026.md
+|   |   |-- loader
 |   |   `-- projects
 |   |       |-- ProjectData.json
 |   |       `-- ProjectData.schema.json
@@ -200,6 +199,7 @@ choco install make
 |   |   |-- archives
 |   |   |   `-- index.astro
 |   |   |-- index.astro
+|   |   |-- loader
 |   |   |-- og.png.ts
 |   |   |-- posts
 |   |   |   |-- [...page].astro
@@ -276,10 +276,8 @@ choco install make
 |       |-- typingAnimation.ts
 |       |-- ytdlpProgress.ts
 |       `-- ytdlpStatus.ts
-|-- tree.txt
 |-- tsconfig.json
 `-- wrangler.jsonc
-
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "astro dev --host",
-    "build": "astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/",
-    "preview": "wrangler pages dev dist",
-    "deploy": "pnpm build && wrangler pages deploy",
+    "build": "astro check && astro build && pagefind --site dist/client && cp -r dist/client/pagefind public/",
+    "preview": "astro preview",
+    "deploy": "pnpm build && wrangler deploy",
     "sync": "astro sync",
     "astro": "astro",
     "format:check": "prettier --check .",

--- a/src/components/ImageViewer.astro
+++ b/src/components/ImageViewer.astro
@@ -1,0 +1,202 @@
+---
+import IconX from "@/assets/icons/IconX.svg";
+import Loader from "@/components/Loader.astro";
+---
+
+<dialog
+  id="global-image-viewer"
+  class="fixed inset-0 z-100 m-auto h-full max-h-none w-full max-w-none items-center justify-center overflow-hidden bg-black/95 p-0 text-white backdrop-blur-md backdrop:bg-transparent [[open]]:flex"
+>
+  <!-- Fullscreen close area -->
+  <button
+    id="iv-close-bg"
+    class="absolute inset-0 z-0 h-full w-full cursor-zoom-out border-none bg-transparent outline-none"
+    aria-label="Close image viewer"></button>
+
+  <!-- Control Header -->
+  <div
+    class="pointer-events-none absolute top-0 left-0 z-20 flex w-full items-center justify-end p-4"
+  >
+    <button
+      id="iv-close-btn"
+      class="pointer-events-auto rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20 focus:outline-none"
+      aria-label="Close image viewer"
+    >
+      <IconX class="size-6" />
+    </button>
+  </div>
+
+  <div
+    id="iv-loading"
+    class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center opacity-0 transition-opacity"
+  >
+    <div class="h-16 w-16">
+      <Loader mode="attached" isSkeleton={false} />
+    </div>
+  </div>
+
+  <!-- Zoom/Pan Container -->
+  <div
+    id="iv-container"
+    class="relative z-10 flex h-full w-full cursor-grab touch-none items-center justify-center active:cursor-grabbing"
+  >
+    <img
+      id="iv-image"
+      src=""
+      alt="Interactive Viewer"
+      class="max-h-full max-w-full origin-center object-contain opacity-0 transition-opacity duration-200 ease-out select-none"
+      draggable="false"
+    />
+  </div>
+</dialog>
+
+<script>
+  const initImageViewer = () => {
+    const dialog = document.getElementById(
+      "global-image-viewer"
+    ) as HTMLDialogElement;
+    const imgBox = document.getElementById("iv-container") as HTMLElement;
+    const img = document.getElementById("iv-image") as HTMLImageElement;
+    const closeBg = document.getElementById("iv-close-bg") as HTMLElement;
+    const closeBtn = document.getElementById("iv-close-btn") as HTMLElement;
+    const loadingEl = document.getElementById("iv-loading") as HTMLElement;
+
+    if (!dialog || dialog.dataset.initialized) return;
+    dialog.dataset.initialized = "true";
+
+    let scale = 1;
+    let translateX = 0;
+    let translateY = 0;
+    let isDragging = false;
+    let startX = 0;
+    let startY = 0;
+
+    let initialPinchDistance = 0;
+    let initialScale = 1;
+    let transformFrame = 0;
+
+    const updateTransform = () => {
+      if (transformFrame) cancelAnimationFrame(transformFrame);
+      transformFrame = requestAnimationFrame(() => {
+        img.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
+      });
+    };
+
+    const resetTransform = () => {
+      scale = 1;
+      translateX = 0;
+      translateY = 0;
+      updateTransform();
+    };
+
+    const closeViewer = () => {
+      if (!dialog.open) return;
+      dialog.close();
+      resetTransform();
+    };
+
+    closeBg.addEventListener("click", closeViewer);
+    closeBtn.addEventListener("click", closeViewer);
+
+    dialog.addEventListener("keydown", e => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeViewer();
+      }
+    });
+
+    window.addEventListener("open-image-viewer", ((e: CustomEvent) => {
+      resetTransform();
+      img.src = e.detail.src;
+      img.classList.remove("opacity-100");
+      img.classList.add("opacity-0");
+      loadingEl.classList.add("opacity-100");
+      loadingEl.classList.remove("opacity-0");
+
+      const onImageLoad = () => {
+        loadingEl.classList.remove("opacity-100");
+        loadingEl.classList.add("opacity-0");
+        img.classList.remove("opacity-0");
+        img.classList.add("opacity-100");
+        img.removeEventListener("load", onImageLoad);
+      };
+
+      img.addEventListener("load", onImageLoad);
+      dialog.showModal();
+    }) as EventListener);
+
+    // Mouse Wheel Zoom
+    imgBox.addEventListener(
+      "wheel",
+      e => {
+        e.preventDefault();
+        const zoomFactor = 0.1;
+        scale =
+          e.deltaY < 0
+            ? Math.min(scale + zoomFactor, 5)
+            : Math.max(scale - zoomFactor, 0.5);
+        updateTransform();
+      },
+      { passive: false }
+    );
+
+    // Drag/Pan (Pointer Events)
+    imgBox.addEventListener("pointerdown", e => {
+      if (e.pointerType === "touch" && !e.isPrimary) return;
+      isDragging = true;
+      startX = e.clientX - translateX;
+      startY = e.clientY - translateY;
+      imgBox.setPointerCapture(e.pointerId);
+    });
+
+    imgBox.addEventListener("pointermove", e => {
+      if (!isDragging) return;
+      translateX = e.clientX - startX;
+      translateY = e.clientY - startY;
+      updateTransform();
+    });
+
+    imgBox.addEventListener("pointerup", e => {
+      isDragging = false;
+      try {
+        imgBox.releasePointerCapture(e.pointerId);
+      } catch {}
+    });
+
+    imgBox.addEventListener("pointercancel", () => {
+      isDragging = false;
+    });
+
+    // Pinch to Zoom (Touch Events)
+    imgBox.addEventListener("touchstart", e => {
+      if (e.touches.length === 2) {
+        isDragging = false;
+        initialPinchDistance = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY
+        );
+        initialScale = scale;
+      }
+    });
+
+    imgBox.addEventListener(
+      "touchmove",
+      e => {
+        if (e.touches.length === 2) {
+          e.preventDefault();
+          const dist = Math.hypot(
+            e.touches[0].clientX - e.touches[1].clientX,
+            e.touches[0].clientY - e.touches[1].clientY
+          );
+          const newScale = initialScale * (dist / initialPinchDistance);
+          scale = Math.min(Math.max(newScale, 0.5), 5);
+          updateTransform();
+        }
+      },
+      { passive: false }
+    );
+  };
+
+  initImageViewer();
+  document.addEventListener("astro:page-load", initImageViewer);
+</script>

--- a/src/components/Loader.astro
+++ b/src/components/Loader.astro
@@ -5,8 +5,11 @@ interface Props {
   mode?: "attached" | "screen" | "overlay" | "background";
   globalHover?: boolean;
   spotlight?: "hover" | "always" | "none";
+  animation?: boolean;
   sweep?: boolean;
   edgeHighlight?: boolean;
+  content?: string;
+  contentHref?: string;
   showIcon?: boolean;
   isSkeleton?: boolean;
   class?: string;
@@ -18,18 +21,27 @@ const {
   mode = "attached",
   globalHover = false,
   spotlight = "hover",
+  animation = false,
   sweep = mode === "attached",
   edgeHighlight = mode === "attached",
-  showIcon = mode === "attached",
+  content = null,
+  contentHref = undefined,
+  showIcon = undefined,
   isSkeleton = false,
   class: className = "",
   label = "Loading",
   message,
 } = Astro.props;
 
+const boolAttr = (value: boolean) => (value ? "true" : "false");
+const loaderContent = content ?? (showIcon ? LoaderSvg : null);
+const isContentHtml =
+  typeof loaderContent === "string" && loaderContent.trim().startsWith("<");
+const hasContent = Boolean(loaderContent);
 const isOverlay = mode === "overlay";
 const isScreen = mode === "screen";
 const isBackground = mode === "background";
+const isAttached = !isOverlay && !isScreen && !isBackground;
 const spotlightEnabled = spotlight !== "none";
 ---
 
@@ -37,7 +49,7 @@ const spotlightEnabled = spotlight !== "none";
   class:list={[
     "loader-container",
     {
-      "loader-container--attached": !isOverlay && !isScreen && !isBackground,
+      "loader-container--attached": isAttached,
       "loader-container--screen": isScreen,
       "loader-container--overlay": isOverlay,
       "loader-container--background": isBackground,
@@ -51,20 +63,17 @@ const spotlightEnabled = spotlight !== "none";
   aria-busy="true"
   aria-label={label}
   data-loader-spotlight={spotlight}
-  data-loader-global-hover={globalHover || isScreen ? "true" : "false"}
-  data-loader-sweep={sweep ? "true" : "false"}
-  data-loader-edge={edgeHighlight ? "true" : "false"}
-  data-loader-icon={showIcon ? "true" : "false"}
-  data-loader-skeleton={isSkeleton ? "true" : "false"}
+  data-loader-global-hover={boolAttr(globalHover || isScreen)}
+  data-loader-animation={boolAttr(animation)}
+  data-loader-sweep={boolAttr(sweep)}
+  data-loader-edge={boolAttr(edgeHighlight)}
+  data-loader-content={boolAttr(hasContent)}
+  data-loader-skeleton={boolAttr(isSkeleton)}
   data-loader-state="enter"
 >
   <div class="loader-frame">
     <div class="loader-reveal">
-      <div
-        class="loader-grid-container"
-        aria-hidden="true"
-        style="container-type: size;"
-      >
+      <div class="loader-grid-container" aria-hidden="true">
         <span class="loader-grid"></span>
 
         {sweep && <span class="loader-sweep" />}
@@ -72,9 +81,27 @@ const spotlightEnabled = spotlight !== "none";
         {spotlightEnabled && <span class="loader-spotlight" />}
 
         {edgeHighlight && <span class="loader-edge" />}
-
-        {showIcon && <span class="loader-icon" set:html={LoaderSvg} />}
       </div>
+
+      {
+        hasContent && (
+          <span class="loader-icon">
+            {contentHref ? (
+              <a class="loader-action" href={contentHref}>
+                {isContentHtml ? (
+                  <span set:html={loaderContent} />
+                ) : (
+                  loaderContent
+                )}
+              </a>
+            ) : isContentHtml ? (
+              <span set:html={loaderContent} />
+            ) : (
+              loaderContent
+            )}
+          </span>
+        )
+      }
 
       {
         message && (
@@ -154,6 +181,7 @@ const spotlightEnabled = spotlight !== "none";
     width: 100%;
     height: 100%;
     min-height: inherit;
+    container-type: size;
   }
 
   .loader-grid-container {
@@ -212,18 +240,43 @@ const spotlightEnabled = spotlight !== "none";
     border-radius: 0;
   }
 
-  .loader-container--overlay .loader-frame {
-    background: var(--background);
-  }
-
   .loader-grid,
   .loader-sweep,
   .loader-edge,
-  .loader-spotlight,
-  .loader-icon {
+  .loader-spotlight {
     position: absolute;
     inset: 0;
     pointer-events: none;
+  }
+
+  .loader-icon {
+    position: absolute;
+    inset: 0;
+    pointer-events: auto;
+    display: none;
+    place-items: center;
+    opacity: 0;
+    transition: opacity 300ms ease;
+    color: var(--loader-text-color);
+  }
+
+  .loader-action {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    width: 100%;
+    height: 100%;
+    color: inherit;
+    text-decoration: none;
+    font: inherit;
+    padding: 0 1rem;
+  }
+
+  .loader-action:hover,
+  .loader-action:focus-visible {
+    outline: none;
+    text-decoration: none;
   }
 
   .loader-grid {
@@ -304,28 +357,10 @@ const spotlightEnabled = spotlight !== "none";
     opacity: 0.95;
   }
 
-  @media (hover: none), (pointer: coarse) {
-    .loader-container[data-loader-spotlight="hover"] .loader-spotlight {
-      opacity: 0.9;
-    }
-  }
-
   @media (prefers-reduced-motion: reduce) {
     .loader-spotlight {
       transition: none;
     }
-  }
-
-  .loader-content {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    padding: 1.5rem;
-    text-align: center;
   }
 
   .loader-message {
@@ -367,6 +402,36 @@ const spotlightEnabled = spotlight !== "none";
     animation: sweep-back-and-forth 1.6s 1 ease-in-out;
   }
 
+  @media (prefers-reduced-motion: no-preference) {
+    .loader-container[data-loader-animation="true"]:not(:hover) .loader-grid {
+      animation: grid-nebula-drift 12s infinite linear;
+    }
+
+    .loader-container[data-loader-animation="true"]:not(:hover)
+      .loader-spotlight {
+      animation: spotlight-breathe 3.6s infinite ease-in-out;
+    }
+
+    .loader-container[data-loader-animation="true"]:not(:hover) .loader-icon {
+      animation: icon-levitate 2.8s infinite ease-in-out;
+    }
+  }
+
+  .loader-container[data-loader-animation="true"][data-loader-sweep="true"]:not(
+      :hover
+    )
+    .loader-sweep {
+    opacity: 0.5;
+    animation: sweep-back-and-forth 2.2s infinite ease-in-out;
+  }
+
+  .loader-container[data-loader-animation="true"]:hover .loader-grid,
+  .loader-container[data-loader-animation="true"]:hover .loader-spotlight,
+  .loader-container[data-loader-animation="true"]:hover .loader-icon,
+  .loader-container[data-loader-animation="true"]:hover .loader-sweep {
+    animation: none;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .loader-sweep {
       animation: none !important;
@@ -383,6 +448,50 @@ const spotlightEnabled = spotlight !== "none";
     50% {
       -webkit-mask-position: -50% 0;
       mask-position: -50% 0;
+    }
+  }
+
+  @keyframes grid-nebula-drift {
+    0% {
+      background-position:
+        0 0,
+        center;
+    }
+    50% {
+      background-position:
+        26px 14px,
+        center;
+    }
+    100% {
+      background-position:
+        0 0,
+        center;
+    }
+  }
+
+  @keyframes spotlight-breathe {
+    0%,
+    100% {
+      opacity: 0.78;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.98;
+      transform: scale(1.06);
+    }
+  }
+
+  @keyframes icon-levitate {
+    0%,
+    100% {
+      transform: translateY(0) scale(1);
+      filter: drop-shadow(0 0 0 transparent);
+    }
+    50% {
+      transform: translateY(-3px) scale(1.04);
+      filter: drop-shadow(
+        0 0 6px color-mix(in srgb, var(--accent) 45%, transparent)
+      );
     }
   }
 
@@ -450,14 +559,6 @@ const spotlightEnabled = spotlight !== "none";
     }
   }
 
-  .loader-icon {
-    display: none;
-    place-items: center;
-    opacity: 0;
-    transition: opacity 300ms ease;
-    color: var(--loader-text-color);
-  }
-
   .loader-icon :global(svg) {
     width: clamp(2rem, 15cqw, 4rem);
     height: clamp(2rem, 15cqw, 4rem);
@@ -478,13 +579,13 @@ const spotlightEnabled = spotlight !== "none";
   }
 
   @media (hover: hover) and (pointer: fine) {
-    .loader-container[data-loader-icon="true"]:hover .loader-icon {
+    .loader-container[data-loader-content="true"]:hover .loader-icon {
       opacity: 1;
     }
-    .loader-container[data-loader-icon="true"]:hover .loader-grid {
+    .loader-container[data-loader-content="true"]:hover .loader-grid {
       opacity: 0.25;
     }
-    .loader-container[data-loader-icon="true"]:hover .loader-sweep {
+    .loader-container[data-loader-content="true"]:hover .loader-sweep {
       opacity: 0.35;
     }
   }
@@ -539,8 +640,19 @@ const spotlightEnabled = spotlight !== "none";
   };
 
   if (typeof window !== "undefined") {
-    window.addEventListener("scroll", updateSkeletonOffsets, { passive: true });
-    window.addEventListener("resize", updateSkeletonOffsets, { passive: true });
+    const loaderGlobal = window as typeof window & {
+      __loaderSkeletonEventsBound?: boolean;
+    };
+
+    if (!loaderGlobal.__loaderSkeletonEventsBound) {
+      window.addEventListener("scroll", updateSkeletonOffsets, {
+        passive: true,
+      });
+      window.addEventListener("resize", updateSkeletonOffsets, {
+        passive: true,
+      });
+      loaderGlobal.__loaderSkeletonEventsBound = true;
+    }
   }
 
   class LoaderManager {
@@ -658,19 +770,21 @@ const spotlightEnabled = spotlight !== "none";
       return saveData || prefersReducedMotion || isCoarsePointer || lowCpuCores;
     }
 
+    private clearSpotlightPosition(): void {
+      this.loader.style.removeProperty("--loader-spotlight-x");
+      this.loader.style.removeProperty("--loader-spotlight-y");
+      this.loader.style.removeProperty("--loader-spotlight-size");
+    }
+
     init(): void {
       if (this.shouldDisableBackgroundSpotlight()) {
-        this.loader.style.removeProperty("--loader-spotlight-x");
-        this.loader.style.removeProperty("--loader-spotlight-y");
-        this.loader.style.removeProperty("--loader-spotlight-size");
+        this.clearSpotlightPosition();
         this.loader.classList.remove("loader-spotlight-active");
         return;
       }
 
       if (this.mode === "none") {
-        this.loader.style.removeProperty("--loader-spotlight-x");
-        this.loader.style.removeProperty("--loader-spotlight-y");
-        this.loader.style.removeProperty("--loader-spotlight-size");
+        this.clearSpotlightPosition();
         return;
       }
 
@@ -761,7 +875,7 @@ const spotlightEnabled = spotlight !== "none";
     }
 
     private setSpotlightToCenter(): void {
-      // In mobile, keeping spotlight fixed at the top-left rather than center.
+      // Keep a fixed top-left anchor on small screens for visual stability.
       const isMobile = window.innerWidth < 768;
 
       this.loader.style.setProperty(
@@ -775,7 +889,7 @@ const spotlightEnabled = spotlight !== "none";
       this.loader.style.setProperty(
         "--loader-spotlight-size",
         isMobile ? "120px" : "180px"
-      ); // The user actually prefers it disabled or top-left.
+      );
     }
   }
 

--- a/src/components/ProjectDialog.astro
+++ b/src/components/ProjectDialog.astro
@@ -160,7 +160,7 @@ const hasUrls = Array.isArray(urls) && urls.length > 0;
             <div class="grid grid-cols-1 gap-6">
               {photos.map(url => (
                 <div
-                  class="image-wrapper relative flex min-h-[300px] w-full flex-col items-center justify-center overflow-hidden rounded-lg bg-background"
+                  class="image-wrapper relative flex min-h-75 w-full flex-col items-center justify-center overflow-hidden rounded-lg bg-background"
                   data-src={url}
                 >
                   <div class="pointer-events-none absolute inset-0 z-0 h-full w-full">
@@ -168,7 +168,7 @@ const hasUrls = Array.isArray(urls) && urls.length > 0;
                       mode="attached"
                       isSkeleton={true}
                       spotlight="none"
-                      class="h-full w-full !bg-transparent"
+                      class="h-full w-full bg-transparent!"
                     />
                   </div>
                 </div>
@@ -273,9 +273,16 @@ const hasUrls = Array.isArray(urls) && urls.length > 0;
         const img = document.createElement("img");
         img.src = url;
         img.className =
-          "relative z-10 w-full h-auto rounded-lg opacity-0 transition-opacity duration-500 bg-background";
+          "relative z-10 w-full h-auto rounded-lg opacity-0 transition-opacity duration-500 bg-background cursor-zoom-in";
         img.loading = "lazy";
         img.alt = "Project Screenshot";
+
+        img.addEventListener("click", () => {
+          const event = new CustomEvent("open-image-viewer", {
+            detail: { src: url },
+          });
+          window.dispatchEvent(event);
+        });
 
         const onImageLoad = () => {
           img.classList.remove("opacity-0");

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
 import { SITE } from "@/config";
 import "@/styles/global.css";
 import Loader from "@/components/Loader.astro";
+import ImageViewer from "@/components/ImageViewer.astro";
 
 type Props = {
   title?: string;
@@ -176,11 +177,13 @@ const structuredData = {
     <Loader
       mode="background"
       globalHover={true}
-      showIcon={false}
       edgeHighlight={false}
       sweep={false}
     />
     <slot />
+
+    <!-- Global Image Viewer for Pannable/Zoomable Images -->
+    <ImageViewer />
 
     <!-- Load full theme logic -->
     <script src="../scripts/theme.ts"></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import getSortedPosts from "@/utils/getSortedPosts";
 import projectsData from "@/data/projects/ProjectData.json";
 import IconRss from "@/assets/icons/IconRss.svg";
 import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
+import LoaderSvg from "@/assets/icons/LoaderPacman.svg?raw";
 import { SITE } from "@/config";
 import { SOCIALS } from "@/constants";
 
@@ -56,6 +57,7 @@ const getTopFeaturedProjects = (
 };
 
 const featuredProjects = getTopFeaturedProjects(projectsData, 3);
+const emptyFeaturedProjectCount = Math.max(0, 3 - featuredProjects.length);
 ---
 
 <Layout>
@@ -133,11 +135,12 @@ const featuredProjects = getTopFeaturedProjects(projectsData, 3);
           <Loader
             mode="attached"
             isSkeleton={true}
-            class="h-full min-h-[160px] w-full"
+            content={LoaderSvg}
+            class="h-full min-h-40 w-full"
+            animation={true}
             spotlight="hover"
             sweep={true}
             edgeHighlight={true}
-            showIcon={true}
           />
         </div>
       </div>
@@ -192,6 +195,21 @@ const featuredProjects = getTopFeaturedProjects(projectsData, 3);
           <ul class="mt-2 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {featuredProjects.map(project => (
               <ProjectCard variant="h3" project={project} />
+            ))}
+            {Array.from({ length: emptyFeaturedProjectCount }).map(() => (
+              <li class="flex h-full flex-col rounded-xl">
+                <Loader
+                  mode="attached"
+                  isSkeleton={true}
+                  content="All Projects →"
+                  contentHref="/projects/"
+                  class="h-full min-h-70 w-full rounded-2xl"
+                  animation={false}
+                  spotlight="hover"
+                  sweep={true}
+                  edgeHighlight={true}
+                />
+              </li>
             ))}
           </ul>
         </section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "public/pagefind"],
+  "exclude": ["dist", "public/pagefind", "dist-pages"],
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,27 +1,30 @@
 {
 	"name": "nuus-portfolio",
-  "pages_build_output_dir": "./dist",
-  "compatibility_date": "2026-02-05",
-  "compatibility_flags": [
-    "nodejs_compat",
-    "global_fetch_strictly_public"
-  ],
+	"main": "@astrojs/cloudflare/entrypoints/server",
+	"assets": {
+		"binding": "ASSETS",
+		"directory": "./dist/client"
+	},
+	"compatibility_date": "2026-02-05",
+	"compatibility_flags": [
+		"nodejs_compat",
+		"global_fetch_strictly_public"
+	],
 	"observability": {
-    "enabled": true
-  },
-  "env": {
-    "preview": {
-      "vars": {
-        "ASTRO_TELEMETRY_DISABLED": "true",
-        "NODE_ENV": "development"
-      }
-    },
-    "production": {
-      "vars": {
-        "ASTRO_TELEMETRY_DISABLED": "true",
-        "NODE_ENV": "production"
-
-      }
-    }
-  }
+		"enabled": true
+	},
+	"env": {
+		"preview": {
+			"vars": {
+				"ASTRO_TELEMETRY_DISABLED": "true",
+				"NODE_ENV": "development"
+			}
+		},
+		"production": {
+			"vars": {
+				"ASTRO_TELEMETRY_DISABLED": "true",
+				"NODE_ENV": "production"
+			}
+		}
+	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,5 +26,6 @@
 				"NODE_ENV": "production"
 			}
 		}
-	}
+	},
+	"workers_dev": false
 }


### PR DESCRIPTION
## Description

This updates the project deployment flow from Cloudflare Pages to Cloudflare Workers and adds explicit preview and production environment selection for manual deploys. It also aligns the build output, Wrangler configuration, and local deploy commands with Astro's Cloudflare server entrypoint and asset layout.

- note : Astro 6 Doesnt Support Cloudflare Pages

**Key additions:**
- Update the manual GitHub Actions workflow to use a deploy_environment choice input for preview or production
- Add authorization validation before setup and deployment in the manual deploy workflow
- Add pnpm setup and switch the deploy step to wrangler deploy with the selected environment
- Update build and deploy scripts to use dist/client output and Astro preview instead of Pages-specific commands
- Refactor Wrangler configuration to use the Cloudflare Workers entrypoint, static asset binding, and environment-specific vars
- Update ignore and TypeScript exclude rules to include dist-pages artifacts
- Image Zoom in out Functionality

## Types of changes
- [x] Build

## Checklist
- [ ] Updated ChangeLog
- [x] Manual deployment workflow updated for environment-based deploys
- [x] Build and deploy scripts aligned with Cloudflare Workers
- [x] Wrangler configuration updated for Astro Cloudflare server output
- [ ] Verified preview and production deployments end to end
