### PR TITLE
[fix(portfolio)] Fix env usage, raw post view, and hardcoded metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
+# For Deployment: Cloudflare Workers + D1(SqlLite)
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ACCOUNT_ID=
+# Disable Astro's telemetry to prevent data collection.
 ASTRO_TELEMETRY_DISABLED=true
+# Backend Server URL - Refer https://github.com/nxdun/rust-codebase.
 BACKEND_SERVER_URL=https://api.nadzu.me
+# Google Services - GTM/ReCAPTCHA
 RECAPTCHA_SITE_KEY=
+PUBLIC_GOOGLE_SITE_VERIFICATION=

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ public/pagefind
 .vscode/
 .wrangler/
 .gemini/
+.antigravitycli/

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 <div align="center">
   <p><strong>Achieves a perfect PageSpeed score (100/100).</strong></p>
   <p>
-    <a href="https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=mobile">Mobile score</a> ·
-    <a href="https://pagespeed.web.dev/analysis/https-nadzu-me/jvq4q0nv5q?form_factor=desktop">Desktop score</a>
+    <a href="https://pagespeed.web.dev/analysis/https-nadzu-me/ns7tgah87m?form_factor=mobile">Mobile score</a> ·
+    <a href="https://pagespeed.web.dev/analysis/https-nadzu-me/ns7tgah87m?form_factor=desktop">Desktop score</a>
   </p>
   <img src="./public/PageSpeed%20Insights.png" alt="PageSpeed Insights" style="max-width: 100%; height: auto; display: block; margin: 1rem 0;" />
 </div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Nuus Portfolio",
+  "name": "nuus-portfolio",
   "type": "module",
   "version": "2.7.1",
   "packageManager": "pnpm@10.33.2",

--- a/src/components/ContactMe.astro
+++ b/src/components/ContactMe.astro
@@ -5,7 +5,7 @@ import { RECAPTCHA_SITE_KEY } from "astro:env/server";
 <section id="contact-me" class="pt-12 pb-6">
   <div class="mx-auto flex flex-col items-center gap-6 lg:w-2/3">
     <h2 id="contact-me-heading" class="mb-4 text-3xl font-bold tracking-wide">
-      Let's Discuss Your Infrastructure.
+      Let's Discuss Your Requirements.
     </h2>
 
     <div id="contact-response-host" class="hidden w-full"></div>

--- a/src/components/ContactMe.astro
+++ b/src/components/ContactMe.astro
@@ -89,6 +89,7 @@ import { RECAPTCHA_SITE_KEY } from "astro:env/server";
 
 <script>
   import { actions } from "astro:actions";
+  import { SITE } from "@/config";
   import type { ToolResponseDock } from "@/scripts/tools/ui/responseDock";
   import type { CaptchaDialogController } from "@/scripts/tools/ui/captchaDialog";
   import type { CaptchaManager } from "@/utils/captchaManager";
@@ -208,7 +209,7 @@ import { RECAPTCHA_SITE_KEY } from "astro:env/server";
           console.error(err);
           responseDock?.setState(
             "fail",
-            "Something went wrong on my end. Please email me directly at hello@nadzu.me"
+            `Something went wrong on my end. Please email me directly at ${SITE.email}`
           );
           submitButton!.disabled = false;
         }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 import Socials from "./Socials.astro";
+import { SITE } from "@/config";
 
 const currentYear = new Date().getFullYear();
 
@@ -23,7 +24,7 @@ const { noMarginTop = false, class: className, ...attrs } = Astro.props;
       <div
         class="my-2 flex flex-col items-center text-sm whitespace-nowrap sm:flex-row"
       >
-        <span>Copyright &#169; nadzu {currentYear}</span>
+        <span>Copyright &#169; {SITE.author} {currentYear}</span>
         <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
         <span>All rights reserved.</span>
       </div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ export const BLOG_PATH = "src/data/blog";
 export const SITE = {
   website: "https://nadzu.me/", // deployed domain
   author: "Nadun Lakshan", //me
+  email: "inbox.nadun@gmail.com",
+  githubUsername: "nxdun",
   profile: "https://nadzu.me/",
   desc: "i am nadun Lakshan, a software engineer with Exceptional DevOps skills i write Blogs about software development, DevOps, and cloud computing.",
   title: "~/nadzu",

--- a/src/data/blog/docker-build-post.md
+++ b/src/data/blog/docker-build-post.md
@@ -1,7 +1,7 @@
 ---
 title: "Rust Docker Builds Under 3 Minutes: ZSTD Builders, Multi-Stage Pipelines, and Multi-Platform OCI Images"
 author: nadzu
-pubDatetime: 2026-05-10T15:39:19Z
+pubDatetime: 2026-05-10T15:39:19+05:30
 slug: docker-cross-platform-build
 featured: true
 draft: false

--- a/src/data/blog/examples/example-draft-post.md
+++ b/src/data/blog/examples/example-draft-post.md
@@ -1,7 +1,7 @@
 ---
 title: Example Draft Post
 author: nadzu
-pubDatetime: 2022-06-06T04:06:31Z
+pubDatetime: 2022-06-06T04:06:31+05:30
 slug: example-draft-post
 featured: false
 draft: true

--- a/src/data/blog/examples/example-featured-post.md
+++ b/src/data/blog/examples/example-featured-post.md
@@ -1,7 +1,7 @@
 ---
 title: Example Featured Post
 author: nadzu
-pubDatetime: 2024-06-06T04:06:31Z
+pubDatetime: 2024-06-06T04:06:31+05:30
 slug: example-featured-post
 featured: true
 draft: true

--- a/src/data/blog/examples/example-non-draft-non-featured-post.md
+++ b/src/data/blog/examples/example-non-draft-non-featured-post.md
@@ -1,7 +1,7 @@
 ---
 title: Example Non-Draft Post
 author: nadzu
-pubDatetime: 2024-06-06T04:06:31Z
+pubDatetime: 2024-06-06T04:06:31+05:30
 slug: example-non-draft-post
 featured: false
 draft: true

--- a/src/data/blog/multi-agentic-system-docs.md
+++ b/src/data/blog/multi-agentic-system-docs.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-Agentic System: Extended Documentation"
 author: nadzu
-pubDatetime: 2026-04-30T10:00:00Z
+pubDatetime: 2026-04-30T10:00:00+05:30
 slug: multi-agentic-system-docs
 featured: false
 draft: true

--- a/src/data/blog/portfolio-changelog-2026.md
+++ b/src/data/blog/portfolio-changelog-2026.md
@@ -1,7 +1,7 @@
 ---
 title: Portfolio Changelog - 2026 Updates
 author: nadzu
-pubDatetime: 2026-05-21T11:21:39Z
+pubDatetime: 2026-05-21T11:21:39+05:30
 slug: portfolio-changelog
 featured: true
 draft: false

--- a/src/data/blog/portfolio-changelog-2026.md
+++ b/src/data/blog/portfolio-changelog-2026.md
@@ -18,7 +18,12 @@ description: Changelog and updates for the portfolio interface.
 ## v.2.7.1 - 2026-05-18
 
 - <a href="https://github.com/nxdun/Portfolio/pull/35" target="_blank" rel="noopener noreferrer"><code>#35</code></a> [docs(changelog)] Add PR #35 to v2.7.1 release notes
-  - Updated dependencies, DOCS, Release notes.
+- Updated dependencies, documentation, and release notes.
+- Added RAW Markdown support for post content; included a "View Raw" button.
+- Moved reusable hardcoded values to the configuration for better maintainability.
+- Bug fix: Off-by-one error in next post calculation.
+- Bug fix: `package.json` has an invalid `name` field.
+- Bug fix: Inconsistency between `import.meta.env` and `astro:env`.
 
 - <a href="https://github.com/nxdun/Portfolio/pull/34" target="_blank" rel="noopener noreferrer"><code>#34</code></a> [chore(deps)] Update dependencies and refine homepage copy
   - Updated dependencies: `@astrojs/cloudflare`, `astro`, `tailwindcss`, `wrangler`, and `@typescript-eslint/parser`.

--- a/src/data/blog/rust-backend-changelog-2026.md
+++ b/src/data/blog/rust-backend-changelog-2026.md
@@ -1,7 +1,7 @@
 ---
 title: Nadzu Backend Changelog - 2026 Updates
 author: nadzu
-pubDatetime: 2026-05-21T11:23:33Z
+pubDatetime: 2026-05-21T11:23:33+05:30
 slug: rust-backend-changelog
 featured: true
 draft: false

--- a/src/data/blog/tool-query-params-2026.md
+++ b/src/data/blog/tool-query-params-2026.md
@@ -1,7 +1,7 @@
 ---
 title: "Tooling Docs: Using Query Parameters for State Persistence"
 author: nadzu
-pubDatetime: 2026-04-19T12:00:00Z
+pubDatetime: 2026-04-19T12:00:00+05:30
 slug: tool-query-params
 # note : soft linked src/pages/tools if you modify this reflect it.
 featured: false

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { Font } from "astro:assets";
 import { ClientRouter } from "astro:transitions";
 import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
+import { BACKEND_SERVER_URL } from "astro:env/server";
 import { SITE } from "@/config";
 import "@/styles/global.css";
 import Loader from "@/components/Loader.astro";
@@ -51,7 +52,7 @@ const structuredData = {
   ],
 };
 
-const toolsBackendUrl = (import.meta.env.BACKEND_SERVER_URL ?? "").trim();
+const toolsBackendUrl = (BACKEND_SERVER_URL ?? "").trim();
 let preconnectOrigin = "";
 // Only preconnect if the page will use the backend API
 if (useBackendApi && toolsBackendUrl) {

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -101,14 +101,16 @@ const nextPost =
     </h1>
     <div class="my-2 flex items-center gap-2">
       <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
-      <span
-        aria-hidden="true"
-        class:list={[
-          "max-sm:hidden",
-          { hidden: !SITE.editPost.enabled || hideEditPost },
-        ]}>|</span
-      >
-      <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+      {
+        SITE.editPost.enabled && !hideEditPost && (
+          <>
+            <span aria-hidden="true" class="max-sm:hidden">
+              |
+            </span>
+            <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+          </>
+        )
+      }
       <span aria-hidden="true" class="max-sm:hidden">|</span>
       <a
         href={`${getPath(post.id, post.filePath, true)}.md`}

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -79,7 +79,9 @@ const currentPostIndex = allPosts.findIndex(a => a.id === post.id);
 
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
-  currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
+  currentPostIndex !== allPosts.length - 1
+    ? allPosts[currentPostIndex + 1]
+    : null;
 ---
 
 <Layout {...layoutProps}>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -13,6 +13,7 @@ import { getPath } from "@/utils/getPath";
 import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
+import IconHash from "@/assets/icons/IconHash.svg";
 import { SITE } from "@/config";
 
 type Props = {
@@ -108,6 +109,16 @@ const nextPost =
         ]}>|</span
       >
       <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+      <span aria-hidden="true" class="max-sm:hidden">|</span>
+      <a
+        href={`${getPath(post.id, post.filePath, true)}.md`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex justify-baseline gap-1.5 opacity-80 hover:text-accent max-sm:hidden"
+      >
+        <IconHash class="inline-block" />
+        <span>View raw</span>
+      </a>
     </div>
     <article
       id="article"
@@ -118,7 +129,18 @@ const nextPost =
 
     <hr class="my-8 border-dashed" />
 
-    <EditPost class="sm:hidden" {hideEditPost} {post} />
+    <div class="flex flex-col gap-2 sm:hidden">
+      <EditPost {hideEditPost} {post} />
+      <a
+        href={`${getPath(post.id, post.filePath, true)}.md`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex justify-baseline gap-1.5 opacity-80 hover:text-accent"
+      >
+        <IconHash class="inline-block" />
+        <span>View raw</span>
+      </a>
+    </div>
 
     <ul class="mt-4 mb-8 flex flex-wrap gap-4 sm:my-8">
       {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} size="sm" />)}

--- a/src/pages/posts/[...slug].md.ts
+++ b/src/pages/posts/[...slug].md.ts
@@ -1,12 +1,13 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import { getPath } from "@/utils/getPath";
+import { SITE } from "@/config";
 import fs from "node:fs/promises";
 import path from "node:path";
 
 export async function getStaticPaths() {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
-  
+
   return posts.map(post => ({
     params: { slug: getPath(post.id, post.filePath, false) },
     props: { post },
@@ -16,22 +17,32 @@ export async function getStaticPaths() {
 export const GET: APIRoute = async ({ props }) => {
   const { post } = props;
   let markdown = "";
-  
+  const origin = SITE.website.replace(/\/$/, "");
+
   try {
     // Attempt to read the raw file directly to include frontmatter
     if (post.filePath) {
       markdown = await fs.readFile(post.filePath, "utf-8");
     } else {
       // Fallback if filePath isn't available
-      const filePath = path.join(process.cwd(), "src/data/blog", post.id);
-      markdown = await fs.readFile(filePath, "utf-8");
+      const baseDir = path.resolve(process.cwd(), "src/data/blog");
+      const resolvedPath = path.resolve(baseDir, post.id);
+
+      // Anti-path traversal check
+      if (!resolvedPath.startsWith(baseDir)) {
+        throw new Error("Invalid path: Path traversal detected");
+      }
+
+      markdown = await fs.readFile(resolvedPath, "utf-8");
     }
   } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`Failed to read markdown for ${post.id}:`, e);
     return new Response("Error reading markdown file", {
       status: 500,
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": origin,
       },
     });
   }
@@ -40,7 +51,7 @@ export const GET: APIRoute = async ({ props }) => {
     status: 200,
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": origin,
     },
   });
 };

--- a/src/pages/posts/[...slug].md.ts
+++ b/src/pages/posts/[...slug].md.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { getPath } from "@/utils/getPath";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  
+  return posts.map(post => ({
+    params: { slug: getPath(post.id, post.filePath, false) },
+    props: { post },
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { post } = props;
+  let markdown = "";
+  
+  try {
+    // Attempt to read the raw file directly to include frontmatter
+    if (post.filePath) {
+      markdown = await fs.readFile(post.filePath, "utf-8");
+    } else {
+      // Fallback if filePath isn't available
+      const filePath = path.join(process.cwd(), "src/data/blog", post.id);
+      markdown = await fs.readFile(filePath, "utf-8");
+    }
+  } catch (e) {
+    return new Response("Error reading markdown file", {
+      status: 500,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
+  return new Response(markdown, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+};

--- a/src/scripts/contributionGraph/index.ts
+++ b/src/scripts/contributionGraph/index.ts
@@ -4,6 +4,7 @@ import type {
   ContributionGraphState,
   ContributionLegendItem,
 } from "./types";
+import { SITE } from "@/config";
 
 const hostSelector = "[data-contribution-graph]";
 const activeControllers = new Set<AbortController>();
@@ -244,7 +245,7 @@ const renderSummary = (
 
   const cacheStatus = data.meta.cached ? "Updated Today" : "Live";
 
-  summaryEl.innerHTML = `<span class="font-semibold text-foreground">nxdun</span> <span class="opacity-70 px-1">/</span> ${data.summary.totalContributions} <span class="opacity-90">contributions</span> <span class="opacity-70 px-1">/</span> ${data.summary.totalWeeks} <span class="opacity-90">weeks</span> <span class="text-[0.65rem] opacity-80 ml-1">(${cacheStatus})</span>`;
+  summaryEl.innerHTML = `<span class="font-semibold text-foreground">${SITE.githubUsername}</span> <span class="opacity-70 px-1">/</span> ${data.summary.totalContributions} <span class="opacity-90">contributions</span> <span class="opacity-70 px-1">/</span> ${data.summary.totalWeeks} <span class="opacity-90">weeks</span> <span class="text-[0.65rem] opacity-80 ml-1">(${cacheStatus})</span>`;
 };
 
 const bindInteraction = (
@@ -253,7 +254,7 @@ const bindInteraction = (
 ) => {
   if (!gridEl || !tooltipEl) return;
 
-  const idleMessage = `<span class="font-semibold text-foreground">nxdun</span> <span class="opacity-50 px-1">/</span> contribution activity`;
+  const idleMessage = `<span class="font-semibold text-foreground">${SITE.githubUsername}</span> <span class="opacity-50 px-1">/</span> contribution activity`;
   tooltipEl.innerHTML = idleMessage;
 
   const updateTooltip = (value: string) => {
@@ -481,14 +482,20 @@ const resolveHost = async (host: HTMLElement) => {
 
       setState(host, "error");
       settleLoaderMotion(host);
-      setStatusMessage(host, "Activity unavailable for nxdun.");
+      setStatusMessage(
+        host,
+        `Activity unavailable for ${SITE.githubUsername}.`
+      );
       return;
     }
 
     if (!isContributionResponse(data)) {
       setState(host, "error");
       settleLoaderMotion(host);
-      setStatusMessage(host, "Activity unavailable for nxdun.");
+      setStatusMessage(
+        host,
+        `Activity unavailable for ${SITE.githubUsername}.`
+      );
       return;
     }
 
@@ -509,7 +516,7 @@ const resolveHost = async (host: HTMLElement) => {
       renderLegend(elements.legend, payload);
       setState(host, "empty");
       settleLoaderMotion(host);
-      setStatusMessage(host, "No recent activity for nxdun.");
+      setStatusMessage(host, `No recent activity for ${SITE.githubUsername}.`);
       return;
     }
 
@@ -542,7 +549,7 @@ const initHost = (host: HTMLElement) => {
 
   host.dataset.contributionGraphInit = "true";
   setState(host, "loading");
-  setStatusMessage(host, "Loading nxdun's activity...");
+  setStatusMessage(host, `Loading ${SITE.githubUsername}'s activity...`);
 
   deferClientWork(() => {
     resolveHost(host);


### PR DESCRIPTION
## Description
This PR fixes several issues in the portfolio app by correcting environment variable usage, normalizing blog post timestamps to the local timezone, and replacing hardcoded metadata with centralized configuration. It also adds a raw Markdown view endpoint for posts and updates ignore patterns for local tooling.

**Key additions:**
- Fix BACKEND_SERVER_URL usage by switching from import.meta.env to astro:env/server
- Fix off-by-one error in next post calculation within PostDetails layout
- Add raw Markdown view endpoint for blog posts with path traversal protection
- Refactor hardcoded email, author, and GitHub username into SITE config
- Update blog post pubDatetime values to include +05:30 timezone offset
- Update .gitignore and .env.example for new local tooling and Google verification keys

## Types of changes
- [x] Feature
- [x] Bugfix


## Checklist
- [x] Updated ChangeLog
- [x] Verified blog post date rendering with new timezone offsets
- [x] Manually tested contact form error state email text
- [ ] Confirmed raw post endpoint works for featured and non-featured posts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View raw" link to access raw markdown for blog posts
  * New endpoint for serving raw blog post markdown files

* **Bug Fixes**
  * Fixed next post selection logic at end of blog list
  * Corrected blog post timestamp formatting with timezone offsets
  * Updated contact form to use dynamic email configuration

* **Chores**
  * Updated environment variable documentation
  * Standardized package naming convention
  * Configured author and social media username from centralized settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxdun/Portfolio/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->